### PR TITLE
fix(portal): stop favicon stampede from starving chat APIs

### DIFF
--- a/enterprise/apps/web-portal/src/app/api/web-search/favicon/route.ts
+++ b/enterprise/apps/web-portal/src/app/api/web-search/favicon/route.ts
@@ -11,16 +11,21 @@ export async function GET(request: Request) {
 
   const payload = await fetchFaviconBytes(host);
   if (!payload) {
-    return new NextResponse(null, { status: 404 });
+    // Negative cache in browser briefly — source lists remount often and must not
+    // re-stampede slow upstream favicon CDNs (was starving /api/chat/.../artifacts).
+    return new NextResponse(null, {
+      status: 404,
+      headers: {
+        "cache-control": "public, max-age=60, stale-while-revalidate=300",
+      },
+    });
   }
 
   return new NextResponse(Buffer.from(payload.bytes), {
     status: 200,
     headers: {
       "content-type": payload.contentType,
-      // Short cache: a prior bug served UTF-8-corrupted bytes with max-age=86400;
-      // avoid sticky broken icons in the browser disk cache.
-      "cache-control": "public, max-age=300, stale-while-revalidate=3600",
+      "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
     },
   });
 }

--- a/enterprise/apps/web-portal/src/components/MachiChatView.tsx
+++ b/enterprise/apps/web-portal/src/components/MachiChatView.tsx
@@ -169,8 +169,12 @@ export function MachiChatView({
   const refreshAvailableModels = React.useCallback(async () => {
     try {
       const res = await fetch("/api/me/models", { cache: "no-store" });
+      if (!res.ok) return;
       const json = (await res.json()) as { data?: { models: PortalModelOption[] } };
       setAvailableModels(json.data?.models ?? []);
+    } catch {
+      // 开发服过载 / 本机代理劫持 localhost 时 fetch 会抛 TypeError: Failed to fetch。
+      // 轮询失败不应打到 Next 运行时错误浮层；保留上一份 models，等下次轮询。
     } finally {
       setModelsLoaded(true);
     }

--- a/enterprise/apps/web-portal/src/lib/web-search/__tests__/direct-fetch.test.ts
+++ b/enterprise/apps/web-portal/src/lib/web-search/__tests__/direct-fetch.test.ts
@@ -42,6 +42,30 @@ describe("directFetch", () => {
     }
   });
 
+  it("honors timeoutMs for hung upstream (does not wait ~20s)", async () => {
+    const server = createServer((_req, _res) => {
+      // never respond
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no port");
+    const url = `http://127.0.0.1:${addr.port}/hang`;
+
+    try {
+      const started = Date.now();
+      await expect(
+        directFetch(url, {
+          method: "GET",
+          timeoutMs: 400,
+          signal: AbortSignal.timeout(400),
+        }),
+      ).rejects.toBeTruthy();
+      expect(Date.now() - started).toBeLessThan(3_000);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
   it("preserves binary bodies with high bytes (favicon PNG)", async () => {
     // Real PNG magic starts with 0x89; UTF-8 string decode would turn it into EF BF BD.
     const png = Buffer.from([

--- a/enterprise/apps/web-portal/src/lib/web-search/__tests__/favicon.test.ts
+++ b/enterprise/apps/web-portal/src/lib/web-search/__tests__/favicon.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { faviconFetchUrls, hostVariants, normalizeFaviconHost } from "../favicon";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  faviconFetchUrls,
+  fetchFaviconBytes,
+  hostVariants,
+  normalizeFaviconHost,
+  resetFaviconCacheForTests,
+} from "../favicon";
+
+afterEach(() => {
+  resetFaviconCacheForTests();
+});
 
 describe("normalizeFaviconHost", () => {
   it("accepts public hostnames", () => {
@@ -28,6 +38,52 @@ describe("faviconFetchUrls", () => {
     const urls = faviconFetchUrls("example.com");
     expect(urls[0]).toContain("duckduckgo.com");
     expect(urls.at(-1)).toContain("google.com/s2/favicons");
+  });
+});
+
+describe("fetchFaviconBytes budget + cache", () => {
+  it("stops within overall budget when upstreams hang", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => resolve(), 5_000);
+        init?.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new DOMException("aborted", "TimeoutError"));
+          },
+          { once: true },
+        );
+      });
+      return new Response(new Uint8Array(32), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    });
+    const started = Date.now();
+    const result = await fetchFaviconBytes("csdn.net", fetchImpl as never);
+    const elapsed = Date.now() - started;
+    expect(result).toBeNull();
+    expect(elapsed).toBeLessThan(4_000);
+  });
+
+  it("dedupes in-flight + caches negative lookups", async () => {
+    let calls = 0;
+    const fetchImpl = vi.fn(async () => {
+      calls += 1;
+      await new Promise((r) => setTimeout(r, 50));
+      return new Response(null, { status: 404 });
+    });
+    const [a, b] = await Promise.all([
+      fetchFaviconBytes("example.com", fetchImpl as never),
+      fetchFaviconBytes("example.com", fetchImpl as never),
+    ]);
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(calls).toBeLessThanOrEqual(4); // one uncached walk, not two full storms
+    const before = calls;
+    await fetchFaviconBytes("example.com", fetchImpl as never);
+    expect(calls).toBe(before); // negative cache hit
   });
 });
 

--- a/enterprise/apps/web-portal/src/lib/web-search/direct-fetch.ts
+++ b/enterprise/apps/web-portal/src/lib/web-search/direct-fetch.ts
@@ -18,7 +18,10 @@ import tls from "node:tls";
 import { URL } from "node:url";
 import type { Duplex } from "node:stream";
 
-export type DirectFetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
+/** Extra `timeoutMs` is honored by curl `--max-time` (AbortSignal alone is not enough). */
+export type DirectFetchInit = RequestInit & { timeoutMs?: number };
+
+export type DirectFetch = (input: string | URL, init?: DirectFetchInit) => Promise<Response>;
 
 function headersToRecord(headers?: HeadersInit): Record<string, string> {
   if (!headers) return {};
@@ -65,9 +68,14 @@ export function resolveHttpProxyUrl(
   return null;
 }
 
-function timeoutMsFromSignal(signal?: AbortSignal | null): number {
-  // AbortSignal.timeout(n) doesn't expose remaining ms; use a sane default.
-  return signal ? 20_000 : 20_000;
+function resolveTimeoutMs(init: DirectFetchInit): number {
+  if (typeof init.timeoutMs === "number" && Number.isFinite(init.timeoutMs) && init.timeoutMs > 0) {
+    return Math.min(Math.floor(init.timeoutMs), 120_000);
+  }
+  // AbortSignal.timeout() does not expose the original ms. When a signal is present,
+  // prefer a short curl --max-time so hung proxy fetches cannot pin Next.js for 20s+.
+  if (init.signal) return 8_000;
+  return 20_000;
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -88,6 +96,7 @@ async function curlFetchWithBody(
   headers: Record<string, string>,
   bodyBuf: Buffer | undefined,
   timeoutMs: number,
+  signal?: AbortSignal | null,
 ): Promise<Response> {
   const parsed = new URL(url);
   return new Promise((resolve, reject) => {
@@ -96,7 +105,8 @@ async function curlFetchWithBody(
       "-X",
       method,
       "--max-time",
-      String(Math.max(1, Math.ceil(timeoutMs / 1000))),
+      // curl accepts fractional seconds (e.g. 1.2); keep aligned with AbortSignal budget.
+      String(Math.max(0.2, Math.round(timeoutMs) / 1000)),
       // Trailer stays ASCII; body stays binary — never decode the whole stdout as utf8.
       "-w",
       "\n__CURL_META__%{http_code}\n%{content_type}",
@@ -120,10 +130,33 @@ async function curlFetchWithBody(
     const child = spawn("curl", args, { env: process.env });
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
+    let settled = false;
+    const settleReject = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", onAbort);
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+      reject(err);
+    };
+    const onAbort = () => {
+      settleReject(new DOMException("The operation was aborted due to timeout", "TimeoutError"));
+    };
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
     child.stdout.on("data", (c) => chunks.push(c));
     child.stderr.on("data", (c) => errChunks.push(c));
-    child.on("error", reject);
+    child.on("error", (err) => settleReject(err instanceof Error ? err : new Error(String(err))));
     child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener("abort", onAbort);
       if (code !== 0) {
         reject(new Error(`curl exit ${code}: ${Buffer.concat(errChunks).toString("utf8")}`));
         return;
@@ -317,11 +350,18 @@ export const directFetch: DirectFetch = async (input, init = {}) => {
   if (bodyBuf && headers["content-length"] == null && headers["Content-Length"] == null) {
     headers["content-length"] = String(bodyBuf.byteLength);
   }
-  const timeoutMs = timeoutMsFromSignal(init.signal);
+  const timeoutMs = resolveTimeoutMs(init);
 
   // 1) curl — best proxy/SOCKS compatibility with shell env
   try {
-    return await curlFetchWithBody(url.toString(), method, headers, bodyBuf, timeoutMs);
+    return await curlFetchWithBody(
+      url.toString(),
+      method,
+      headers,
+      bodyBuf,
+      timeoutMs,
+      init.signal,
+    );
   } catch {
     // fall through
   }

--- a/enterprise/apps/web-portal/src/lib/web-search/favicon.ts
+++ b/enterprise/apps/web-portal/src/lib/web-search/favicon.ts
@@ -2,7 +2,32 @@
  * Server-side favicon fetch for portal UI (client cannot rely on Google s2 in CN).
  */
 
-import { directFetch } from "./direct-fetch";
+import { directFetch, type DirectFetch } from "./direct-fetch";
+
+export type FaviconPayload = {
+  bytes: Uint8Array;
+  contentType: string;
+};
+
+/** Per upstream candidate — keep short so Clash/proxy hangs cannot pin Next.js. */
+const PER_URL_MS = 1_200;
+/** Hard budget for the whole host (all variants × candidates). */
+const OVERALL_MS = 2_500;
+const POSITIVE_TTL_MS = 5 * 60_000;
+const NEGATIVE_TTL_MS = 60_000;
+
+type CacheEntry =
+  | { ok: true; payload: FaviconPayload; expiresAt: number }
+  | { ok: false; expiresAt: number };
+
+const faviconCache = new Map<string, CacheEntry>();
+const faviconInflight = new Map<string, Promise<FaviconPayload | null>>();
+
+/** Test-only: clear process-local favicon cache / in-flight map. */
+export function resetFaviconCacheForTests(): void {
+  faviconCache.clear();
+  faviconInflight.clear();
+}
 
 const HOST_RE = /^(?=.{1,253}$)(?!-)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
 const BLOCKED_HOSTS = new Set([
@@ -65,11 +90,6 @@ export function faviconFetchUrls(host: string): string[] {
   ];
 }
 
-export type FaviconPayload = {
-  bytes: Uint8Array;
-  contentType: string;
-};
-
 function sniffContentType(bytes: Uint8Array, fallback: string): string {
   if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
     return "image/jpeg";
@@ -113,20 +133,25 @@ function sniffContentType(bytes: Uint8Array, fallback: string): string {
   return fallback.includes("image/") ? fallback : "image/x-icon";
 }
 
-export async function fetchFaviconBytes(
+async function fetchFaviconBytesUncached(
   host: string,
-  fetchImpl: typeof fetch = directFetch as unknown as typeof fetch,
+  fetchImpl: DirectFetch,
 ): Promise<FaviconPayload | null> {
   const variants = hostVariants(host);
   if (variants.length === 0) return null;
 
+  const started = Date.now();
   for (const variant of variants) {
     for (const url of faviconFetchUrls(variant)) {
+      const elapsed = Date.now() - started;
+      if (elapsed >= OVERALL_MS) return null;
+      const perTry = Math.min(PER_URL_MS, Math.max(200, OVERALL_MS - elapsed));
       try {
         const res = await fetchImpl(url, {
           method: "GET",
           headers: { accept: "image/*,*/*;q=0.8" },
-          signal: AbortSignal.timeout(8_000),
+          signal: AbortSignal.timeout(perTry),
+          timeoutMs: perTry,
           redirect: "follow",
         });
         if (!res.ok) continue;
@@ -144,4 +169,44 @@ export async function fetchFaviconBytes(
     }
   }
   return null;
+}
+
+export async function fetchFaviconBytes(
+  host: string,
+  fetchImpl: DirectFetch = directFetch,
+): Promise<FaviconPayload | null> {
+  const cacheKey = normalizeFaviconHost(host);
+  if (!cacheKey) return null;
+
+  const cached = faviconCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.ok ? cached.payload : null;
+  }
+
+  const existing = faviconInflight.get(cacheKey);
+  if (existing) return existing;
+
+  const run = (async () => {
+    const payload = await fetchFaviconBytesUncached(cacheKey, fetchImpl);
+    if (payload) {
+      faviconCache.set(cacheKey, {
+        ok: true,
+        payload,
+        expiresAt: Date.now() + POSITIVE_TTL_MS,
+      });
+    } else {
+      faviconCache.set(cacheKey, {
+        ok: false,
+        expiresAt: Date.now() + NEGATIVE_TTL_MS,
+      });
+    }
+    return payload;
+  })();
+
+  faviconInflight.set(cacheKey, run);
+  try {
+    return await run;
+  } finally {
+    faviconInflight.delete(cacheKey);
+  }
 }

--- a/enterprise/features/chat/src/components/molecules/WebSearchFavicon.tsx
+++ b/enterprise/features/chat/src/components/molecules/WebSearchFavicon.tsx
@@ -82,7 +82,9 @@ async function fetchBffFaviconObjectUrl(host: string): Promise<string | null> {
   for (const variant of variants) {
     const url = `/api/web-search/favicon?host=${encodeURIComponent(variant)}&v=2`;
     try {
-      const res = await fetch(url, { cache: "no-store", credentials: "same-origin" });
+      // Honor BFF Cache-Control — `no-store` previously re-stampeded slow favicon
+      // upstreams on every source-chip remount and starved other portal APIs.
+      const res = await fetch(url, { credentials: "same-origin" });
       if (!res.ok) continue;
       const bytes = new Uint8Array(await res.arrayBuffer());
       if (!looksLikeImageBytes(bytes)) continue;

--- a/enterprise/scripts/start-dev-with-infra.sh
+++ b/enterprise/scripts/start-dev-with-infra.sh
@@ -32,6 +32,7 @@ start-dev-with-infra.sh — 本地开发一键启动（中间件 + 应用）
   --db=postgresql|mysql  选择业务数据库（默认 postgresql）
   --all                  透传给 start-dev.sh（enterprise + customers）
   --ui=tui|stream        透传给 start-dev.sh
+  --webpack              透传给 start-dev.sh（Next 不用 Turbopack）
   --infra-only           仅启动所选数据库 + Redis，不启动应用
   --skip-infra           跳过中间件启动，直接启动应用
   --down                 仅关闭中间件（不启动应用）
@@ -46,7 +47,7 @@ for arg in "$@"; do
     --infra-only) INFRA_ONLY=1 ;;
     --skip-infra) SKIP_INFRA=1 ;;
     --down) DOWN_ONLY=1 ;;
-    --all|--ui=tui|--ui=stream) APP_ARGS+=("$arg") ;;
+    --all|--ui=tui|--ui=stream|--webpack) APP_ARGS+=("$arg") ;;
     -h|--help) print_help; exit 0 ;;
     *)
       echo "[start-dev-with-infra] 未知参数: $arg" >&2

--- a/enterprise/scripts/start-dev.sh
+++ b/enterprise/scripts/start-dev.sh
@@ -10,6 +10,7 @@
 #   bash scripts/start-dev.sh              # 仅 enterprise（推荐日常）
 #   bash scripts/start-dev.sh --all        # enterprise + customers/*
 #   bash scripts/start-dev.sh --ui=stream  # 关闭 Turbo TUI，输出纯日志
+#   bash scripts/start-dev.sh --webpack    # Next 不用 Turbopack（本机卡死/Failed to fetch 时用）
 #   bash scripts/start-dev.sh -h           # 帮助
 
 set -euo pipefail
@@ -22,6 +23,7 @@ source "$SCRIPT_DIR/lib/logging.sh"
 
 ALL_APPS=0
 TURBO_UI="tui"
+USE_WEBPACK=0
 
 print_help() {
   cat <<'EOF'
@@ -35,6 +37,8 @@ start-dev.sh — 本机启动 enterprise 一条命令
   --ui=tui | --ui=stream
                         Turbo UI 模式：tui（默认，可上下键切任务）
                         或 stream（无交互，纯日志滚动，方便看 Ctrl+C 与日志）
+  --webpack             Next 走 webpack（package.json 的 dev:webpack），不用 --turbopack。
+                        本机出现「加载很久 → Failed to fetch」、next-server CPU 长期很高时可试。
   -h, --help            显示本帮助
 
 端口：
@@ -51,6 +55,7 @@ for arg in "$@"; do
     --all) ALL_APPS=1 ;;
     --ui=tui) TURBO_UI="tui" ;;
     --ui=stream) TURBO_UI="stream" ;;
+    --webpack) USE_WEBPACK=1 ;;
     -h|--help) print_help; exit 0 ;;
     *) echo "[start-dev] 未知参数: $arg (可用 --help 查看)" >&2; exit 2 ;;
   esac
@@ -250,13 +255,21 @@ else
   SCOPE="ALL workspace apps (enterprise + customers/*)"
 fi
 
-echo "[start-dev] booting Next apps → $SCOPE"
+NEXT_DEV_SCRIPT="dev"
+if [ "$USE_WEBPACK" -eq 1 ]; then
+  NEXT_DEV_SCRIPT="dev:webpack"
+fi
+
+echo "[start-dev] booting Next apps → $SCOPE (script=$NEXT_DEV_SCRIPT)"
+if [ "$USE_WEBPACK" -eq 1 ]; then
+  echo "[start-dev] Next bundler: webpack（已跳过 --turbopack）"
+fi
 if [ "$TURBO_UI" = "tui" ]; then
   echo "[start-dev] 提示：pnpm parallel 无 Turbo TUI；要看纯日志可加 --ui=stream（行为相同）。"
 fi
 (
   cd "$ENTERPRISE_DIR"
-  exec pnpm "${PNPM_DEV_FILTERS[@]}" --parallel dev
+  exec pnpm "${PNPM_DEV_FILTERS[@]}" --parallel "$NEXT_DEV_SCRIPT"
 ) &
 PIDS+=("$!")
 


### PR DESCRIPTION
## Summary
- Cap `/api/web-search/favicon` fetch budgets, add in-process cache + in-flight dedupe, and honor `timeoutMs`/abort in `directFetch` curl path so slow outbound icon fetches cannot pin the Next process.
- Avoid remount stampede (`cache: "no-store"`) on source chips; swallow models-poll network errors so they do not surface as runtime overlays.
- Add `start-dev --webpack` / `start-dev-with-infra --webpack` as a local fallback when Turbopack overloads the machine.

Root cause observed in deep-research UI: favicon BFF calls taking ~9–11s each starved `/api/chat/sessions/*/artifacts`, producing「全部文件」`Failed to fetch`. Same code path exists on `main`.

## Test plan
- [ ] `pnpm -C enterprise/apps/web-portal exec vitest run src/lib/web-search/__tests__/favicon.test.ts src/lib/web-search/__tests__/direct-fetch.test.ts`
- [ ] Open a deep-research session with many sources; confirm favicon logs are no longer ~9s storms
- [ ] Open「全部文件」and confirm artifact list loads
- [ ] Optional: `bash scripts/start-dev-with-infra.sh --skip-infra --db=mysql --ui=stream --webpack` boots with `script=dev:webpack`