### PR TITLE
docs: add optional remote search MCP example

### DIFF
--- a/docs/guides/near-remote-mcp.md
+++ b/docs/guides/near-remote-mcp.md
@@ -85,7 +85,9 @@ Near（`agx serve` + Desktop）从 **Phase 1+2** 起支持在 `~/.agenticx/mcp.j
 }
 ```
 
-该端点无需账户或 API key，`headers` 可省略。原生 `/mcp` URL 会按上述规则选择 `streamable_http`。仅在用户显式调用其工具时使用；用户提供的搜索目标、搜索查询和请求的 URL 会发送给 Parallel。详见 [Parallel Search MCP 文档](https://docs.parallel.ai/integrations/mcp/search-mcp)。
+该端点支持匿名免费访问，无需账户或 API key，`headers` 可省略，但匿名免费层的速率限制较低。若需更高的速率限制，可在 `parallel-search` 条目的 `headers` 中添加 `"Authorization": "Bearer YOUR_PARALLEL_API_KEY"`，将占位符替换为自己的 Parallel API key。原生 `/mcp` URL 会按上述规则选择 `streamable_http`。
+
+连接后，模型可能根据任务需要调用已启用的 `web_search` 或 `web_fetch`；调用时，工具参数（包括搜索目标、搜索查询和请求的 URL）会发送给 Parallel。详见 [Parallel Search MCP 文档](https://docs.parallel.ai/integrations/mcp/search-mcp)。
 
 ### 示例：Enterprise Gateway 托管 MCP
 

--- a/docs/guides/near-remote-mcp.md
+++ b/docs/guides/near-remote-mcp.md
@@ -71,6 +71,22 @@ Near（`agx serve` + Desktop）从 **Phase 1+2** 起支持在 `~/.agenticx/mcp.j
 }
 ```
 
+### 示例（可选）：Parallel Search MCP
+
+仅在用户明确选择使用时，将 `parallel-search` 条目**合并**到现有 `mcpServers` 中；不要替换整个 `mcpServers`，也不要覆盖任何已有的服务器条目、Provider、用户默认值或安全设置。
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+该端点无需账户或 API key，`headers` 可省略。原生 `/mcp` URL 会按上述规则选择 `streamable_http`。仅在用户显式调用其工具时使用；用户提供的搜索目标、搜索查询和请求的 URL 会发送给 Parallel。详见 [Parallel Search MCP 文档](https://docs.parallel.ai/integrations/mcp/search-mcp)。
+
 ### 示例：Enterprise Gateway 托管 MCP
 
 将 [方式 A](#方式-a注册中心一键发现) 或 [方式 B](#方式-b手动添加-streamable-http) 得到的 `streamable-http` URL 写入 `url`，PAT 写入 `headers`：


### PR DESCRIPTION
## Why

Near supports remote URL MCP servers, but the guide did not include an optional account-free search and URL-fetching example. This adds an explicit opt-in example without changing any existing provider, server, default, authentication, or security behavior.

## Changes

- Add a separate optional `parallel-search` entry using `https://search.parallel.ai/mcp` next to the existing hosted MCP example.
- Clarify that users must merge the entry into their existing `mcpServers` mapping and must not replace or overwrite existing configuration.
- Document that the native `/mcp` URL selects `streamable_http`, while headers are optional and the endpoint needs no account or API key.
- Disclose that when users explicitly invoke these tools, user-provided search objectives, search queries, and requested URLs are sent to Parallel.

## Validation

- `git diff --check`: passed.
- One-file scope and `git status --short` check: passed.
- Documentation content assertions for opt-in, merge safety, endpoint, transport, optional headers, privacy disclosure, and canonical documentation link: passed.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.