### PR TITLE
fix(enterprise): require a boolean password-change flag on auth context

### DIFF
--- a/enterprise/packages/auth/src/types.ts
+++ b/enterprise/packages/auth/src/types.ts
@@ -18,7 +18,7 @@ export type AuthContext = {
   deptId?: string | null;
   email: string;
   scopes: string[];
-  mustChangePassword?: boolean;
+  mustChangePassword: boolean;
   sessionId: string;
 };
 


### PR DESCRIPTION
## Summary

- `AuthContext.mustChangePassword` is now a required boolean, matching token payloads.
- This unblocks the admin-console production typecheck that failed on `issueTokens` after first-login password change landed.

## Test plan

- [ ] `@agenticx/auth` password-change tests pass
- [ ] Admin-console Vercel preview / `next build` no longer reports `boolean | undefined` at `auth.ts:141`