### PR TITLE
fix(runtime): persist group images and let Near see them

### DIFF
--- a/.cursor/plans/2026-08-29-group-chat-image-inputs.plan.md
+++ b/.cursor/plans/2026-08-29-group-chat-image-inputs.plan.md
@@ -1,0 +1,506 @@
+# 群聊当轮用户图片注入 LLM
+
+Planned-with: Cursor Grok 4.6
+Suggested-Impl-Model: Composer 2.5（后端接线：`append_user` + scratchpad stash + `_run_one_target` 透传已有 `run_turn` 参数；plan 已写清落点与 before/after，不必上顶配）
+Status: ready
+Plan-Id: 2026-08-29-group-chat-image-inputs
+
+> **For implementer:** 只改本 plan 列出的路径。触碰 `agenticx/studio/server.py` 时**只能**在现有 `router.run_group_turn(...)` 调用上精确增加两个 kwargs，禁止整段替换 import 或相邻 handler。不要改 Desktop、不要改单聊 promote、不要改 `_call_llm_text`。不要 commit，除非用户明确要求。
+
+**Goal:** 群聊当轮用户上传的图片写入 `messages.json`，并随成员 `AgentRuntime.run_turn` 进入多模态上下文，行为对齐单聊。
+
+**Architecture:** Desktop 已发 `image_inputs`；Studio 已 normalize 出 `image_inputs` / `history_image_attachments`。缺口在群聊分叉：`run_group_turn` 只收纯文本。本轮把这两份列表传入 router，经 `append_user` 落盘，并用 session scratchpad 暂存，让所有 `_run_one_target` 路径（含 mention follow-up）无需改十多处签名即可读到图。视觉成员拼 `user_message_content`（text + `image_url`）；非视觉成员走已有 `history_user_attachments` + autodescribe / omit notice。
+
+**Tech Stack:** Python、`GroupChatContext`、`GroupChatRouter`、`AgentRuntime.run_turn`、FastAPI `/api/chat`、pytest。
+
+---
+
+## 根因与证据链（实施者勿依赖对话记忆）
+
+复现：群聊 session 选多模态模型，发带 `image.png` 的用户消息。UI 气泡有附件，助手回复「没收到图、只有文字」。
+
+磁盘证据（本机群聊 session `~/.agenticx/sessions/<group-session-id>/messages.json`）：
+
+- 用户那条消息**没有** `attachments` 字段，只有纯文本。
+- 同目录 `agent_messages.json` 也搜不到 `attachments` / `data:image`。
+
+单聊能看见的完整链路（**不要改这些文件的既有逻辑**，只对照）：
+
+1. Desktop `desktop/src/components/ChatPane.tsx` 把带 `dataUrl` 的图放进 `body.image_inputs`（群聊同样会发，前端不用改）。
+2. `agenticx/studio/server.py` `_normalize_image_inputs`（约 L1795）+ `_history_attachments_from_image_inputs`（约 L1830）生成两份列表。`history_image_attachments` 在「非视觉则清空 `image_inputs`」（约 L2923–2927）**之前**就算好（约 L2832）。
+3. 单聊约 L3789–3822 拼 `user_message_content`，并传 `history_user_attachments` 给 `AgentRuntime.run_turn`。
+4. `agenticx/runtime/agent_runtime.py` `_promote_user_image_attachments`（约 L1291）在视觉模型下把历史 `attachments.data_url` 提升成多模态 content。
+
+群聊丢图的分叉：
+
+1. `is_group_session` 后走 `_produce_group_events()`（`server.py` 约 L3126）。
+2. `router.run_group_turn(...)`（约 L3211）**只传 `user_input` 文本**，不传 `image_inputs` / `history_image_attachments`。
+3. `GroupChatContext.append_user()`（`agenticx/runtime/group_context.py` L50–69）只写纯文字，没有 `attachments` 参数。
+4. `_run_one_target`（`group_router.py` L1452）新建空的 `local_session`，历史只靠 `context.render_recent_dialogue()` 压成系统提示里的文字。
+5. `runtime.run_turn(...)`（约 L1606）**没有** `user_message_content` / `history_user_attachments`。
+6. `_run_one_target_stream`（约 L1737）只是包一层 `_run_one_target`，同样没带图。
+
+2026-06-12 的 plan（`.cursor/plans/2026-06-12-chat-image-attachments-persistence-vision-history-reconstruction.plan.md`，status Implemented）要求群聊也持久化 `data_url`，但实际只修了单聊。
+
+```mermaid
+flowchart TD
+  A["Desktop POST /api/chat<br/>image_inputs"] --> B["server.py normalize<br/>history_image_attachments"]
+  B --> C{"is_group_session?"}
+  C -->|否| D["run_turn<br/>user_message_content + attachments"]
+  C -->|是| E["run_group_turn<br/>今天只传 user_input"]
+  E --> F["append_user 纯文本"]
+  E --> G["_run_one_target<br/>空 local_session"]
+  G --> H["run_turn 只有文字"]
+  D --> I["模型看见图"]
+  H --> J["模型只看见字"]
+```
+
+---
+
+## 推荐实施模型
+
+| 子任务 | 推荐模型 | 理由 |
+|---|---|---|
+| `append_user` + 单测 | Composer 2.5 | 对齐已有 `append_agent`，样板 |
+| scratchpad stash + `_run_one_target` 透传 | Composer 2.5 | 接线清晰，签名默认值避免改调用点 |
+| `server.py` 两个 kwargs | Composer 2.5 | 精确插行，禁止整段替换 |
+| Studio FakeRouter 单测 | Composer 2.5 | 仿 `test_group_chat_hydrates_document_before_router_turn` |
+
+最终 `Impl-Model` trailer 以实际使用为准，由用户确认。未提供时询问，禁止编造。
+
+---
+
+## In scope
+
+- `GroupChatContext.append_user` 可选 `attachments`，有则写入（对齐 `append_agent`）
+- `run_group_turn` 接收 `image_inputs` / `history_image_attachments`，`append_user` 带附件，scratchpad 暂存本轮图
+- `_run_one_target` 读 scratchpad，按成员 `is_vision_capable` 拼 `user_message_content`，并传 `history_user_attachments`
+- `server.py` 现有 `run_group_turn(...)` 增加两个 kwargs
+- 上表所列测试
+
+## Out of scope
+
+- Desktop `ChatPane` / 前端发送（已经发 `image_inputs`）
+- 单聊 `user_message_content` / `_promote_user_image_attachments` 既有逻辑
+- `_call_llm_text` / `_run_meta_project_manager_reply`（纯文本 PM 路径；本次 Near 主答走 `_run_one_target(META)`）
+- Workforce 规划层 LLM、intent `_analyze_intent` 文本 prompt
+- 跨轮「上一张图」重建：`local_session` 每轮是空的，`render_recent_dialogue()` 只有字。当轮注入 + 落盘即可修本次 bug
+- 非视觉时清空 `image_inputs` 的 session 级逻辑（约 L2923）；用 `history_image_attachments` 给视觉成员重建
+- `server.py` 顶部 import 区
+- 改 `persist_user_message` 默认值
+- 给十多处 `_run_one_target` / `_run_one_target_stream` 调用逐个加参数（用 scratchpad，禁止签名扩散）
+
+## no-scope-creep
+
+每个改动必须能追溯到下面某条 FR。禁止顺手重构 `group_router.py` 其它路由、禁止改 Desktop、禁止改单聊。新参数必须有默认值 `None` / 空列表，现有 `tests/test_smoke_group_*.py` 调用点不用改。
+
+---
+
+## FR-1：`append_user` 可写图片附件
+
+**Files:**
+
+- Modify: `agenticx/runtime/group_context.py` — `GroupChatContext.append_user`（L50–69）
+- Test: `tests/test_group_shared_artifact_delivery.py` — 紧挨现有 `test_append_agent_attachments_match_session_schema`（约 L342）
+
+**Before:** `append_user` 只写 `role/content/sender_*`，无 `attachments`。
+
+**After:** 增加可选 `attachments: Sequence[Mapping[str, Any]] | None = None`。非空时写入 `row["attachments"] = [dict(item) for item in attachments]`，与 `append_agent`（L89–90）相同。空或 `None` 不写该键。
+
+完整签名与实现意图：
+
+```python
+def append_user(
+    self,
+    text: str,
+    *,
+    sender_name: str = "我",
+    quoted_message_id: str = "",
+    quoted_content: str = "",
+    attachments: Sequence[Mapping[str, Any]] | None = None,
+) -> None:
+    label = str(sender_name or "").strip() or "我"
+    row: dict[str, Any] = {
+        "role": "user",
+        "content": str(text or ""),
+        "sender_id": "user",
+        "sender_name": label,
+        "agent_id": "user",
+        "quoted_message_id": str(quoted_message_id or ""),
+        "quoted_content": str(quoted_content or ""),
+    }
+    if attachments:
+        row["attachments"] = [dict(item) for item in attachments]
+    self._history().append(row)
+```
+
+`from typing import Any, List, Mapping, Sequence` 文件顶部已有，不必新增 import。
+
+**AC-1:**
+
+- 测试名：`test_append_user_persists_image_attachments`
+- 用 `SimpleNamespace(chat_history=[], scratchpad={})` + `GroupChatContext`
+- `append_user("看这张图", attachments=[{"name": "image.png", "mime_type": "image/png", "size": 12, "data_url": TINY_PNG}])`
+- 断言 `session.chat_history[-1]["attachments"][0]["data_url"]` 以 `data:image/` 开头，且 `name == "image.png"`
+- 再 `append_user("纯文字")`，断言最后一条**没有** `attachments` 键
+
+测试用 1×1 PNG（全文写进测试，禁止「按需推断」）：
+
+```python
+TINY_PNG = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+```
+
+可把 `TINY_PNG` 放在该测试文件模块级常量，供后续 FR 测试复用。
+
+---
+
+## FR-2：`run_group_turn` 接收图、落盘、scratchpad 暂存
+
+**Files:**
+
+- Modify: `agenticx/runtime/group_router.py` — `run_group_turn`（L2656–2683）
+- Test: `tests/test_group_shared_artifact_delivery.py`
+
+**Scratchpad 键（写死，禁止改名）：**
+
+- `__group_turn_image_inputs__`
+- `__group_turn_history_attachments__`
+
+**Before:** `run_group_turn` 无图参数；`append_user` 只传文本。
+
+**After:**
+
+1. 签名增加（必须有默认，现有调用全不用改）：
+
+```python
+image_inputs: Sequence[Mapping[str, Any]] | None = None,
+history_image_attachments: Sequence[Mapping[str, Any]] | None = None,
+```
+
+插在 `user_display_name` 之后、`) -> AsyncGenerator` 之前。`Mapping` 已在 `group_router.py` L17 导入。
+
+2. 在 `scratchpad` 规范化之后、`append_user` **之前**，写入并保证是 list 拷贝（避免调用方后续清空污染本轮）：
+
+```python
+turn_images = [dict(item) for item in (image_inputs or []) if isinstance(item, Mapping)]
+turn_history = [
+    dict(item) for item in (history_image_attachments or []) if isinstance(item, Mapping)
+]
+if not turn_history and turn_images:
+    turn_history = _attachments_from_image_inputs(turn_images)
+scratchpad["__group_turn_image_inputs__"] = turn_images
+scratchpad["__group_turn_history_attachments__"] = turn_history
+```
+
+3. `append_user` 增加 `attachments=turn_history or None`。
+
+4. **整个 `run_group_turn` 体用 try/finally**：`finally` 里 `scratchpad.pop("__group_turn_image_inputs__", None)` 与 `scratchpad.pop("__group_turn_history_attachments__", None)`。当前函数在 `routing == "team"` / `"intelligent"` 处有提前 `return`，必须包进 try，否则下一轮会漏图。
+
+模块级小助手（放在 `group_router.py` 文件前部、`META_LEADER_AGENT_ID` 常量附近即可，不要新建文件）：
+
+```python
+def _attachments_from_image_inputs(
+    items: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for im in items or []:
+        if not isinstance(im, Mapping):
+            continue
+        data_url = str(im.get("data_url") or "").strip()
+        if not data_url.startswith("data:image/"):
+            continue
+        out.append(
+            {
+                "name": str(im.get("name") or "image").strip() or "image",
+                "mime_type": str(im.get("mime_type") or "image/png").strip() or "image/png",
+                "size": int(im.get("size") or 0) if str(im.get("size") or "").strip() != "" else 0,
+                "data_url": data_url,
+            }
+        )
+    return out
+```
+
+`size` 解析要对齐 server：`int(im.get("size") or 0)`，`TypeError`/`ValueError` 时用 `0`。上面伪代码若 `int(...)` 可能炸，实施时用 try/except，与 `server.py` L1845–1848 一致。
+
+**AC-2:**
+
+- 测试名：`test_run_group_turn_persists_user_image_attachments`
+- 复用同文件 `_make_router()` / `_session_with_workspace`
+- `monkeypatch` `AgentRuntime` 为立即 `yield FINAL` 的 stub（抄 `test_member_prompt_mentions_shared_workspace` 的 `_CapturingRuntime`）
+- session 设 `provider_name="openai"`、`model_name="gpt-4o"`（视觉宽松，未知 slug 也默认视觉）
+- `session.__group_avatar_ids = ["a1"]`
+- `await` 消费完 `router.run_group_turn(..., routing="broadcast" 或能打到 `_run_one_target` 的 routing，`mentioned_avatar_ids=["a1"]`, `user_input="看图", image_inputs=[{"name":"image.png","data_url":TINY_PNG,"mime_type":"image/png","size":70}], history_image_attachments=[{"name":"image.png","mime_type":"image/png","size":70,"data_url":TINY_PNG}])`
+- 断言 `session.chat_history` 里**第一条 user 行**含 `attachments[0].data_url == TINY_PNG`
+- 断言函数返回后 scratchpad **没有** `__group_turn_image_inputs__` / `__group_turn_history_attachments__`
+
+`routing` 取值：看 `pick_targets`。最稳是 `mentioned_avatar_ids=["a1"]` 且 routing 不是 `team`/`intelligent`（例如 `"user-directed"` 或现有 smoke 测试用的值）。打开任意 `tests/test_smoke_group_legacy_routing.py` 里 `run_group_turn` 的 `routing=` 抄同一个字符串。若不确定，用 `routing="intelligent"` 并 mock `_run_intelligent_turn` **不要**——那会跳过 `_run_one_target`。本测只验 persist + finally 清理，可 `monkeypatch` `pick_targets` 返回 `["a1"]`，`routing="sequential"`（或该文件其它测试用过的非 team/intelligent 值）。
+
+查 `pick_targets` 对未知 routing 的行为：若会落到 `targets = self.pick_targets(...)`（L2725），则设 `mentioned_avatar_ids=["a1"]` 即可。
+
+---
+
+## FR-3：`_run_one_target` 把本轮图交给 `run_turn`
+
+**Files:**
+
+- Modify: `agenticx/runtime/group_router.py` — `_run_one_target` 的 `runtime.run_turn(...)`（约 L1606–1615）
+- 同文件增加 `_group_turn_image_blocks` 助手
+- Test: `tests/test_group_shared_artifact_delivery.py`
+
+**不要**给 `_run_one_target` 加新必填参数。从 `base_session.scratchpad` 读 FR-2 的两个键。
+
+**Before:**
+
+```python
+async for event in runtime.run_turn(
+    local_user_input,
+    local_session,
+    should_stop=lambda: self._should_stop(should_stop),
+    agent_id=avatar_id,
+    tools=_group_chat_tools(),
+    system_prompt=system_prompt,
+    usage_session_id=str(getattr(base_session, "_usage_owner_session_id", "") or ""),
+    usage_avatar_id=str(avatar_id or ""),
+):
+```
+
+**After:** 在该调用前（`final_text = ""` 附近，`run_turn` 正上方）插入：
+
+```python
+from agenticx.llms.vision import is_vision_capable
+
+_sp = getattr(base_session, "scratchpad", None)
+if not isinstance(_sp, dict):
+    _sp = {}
+_turn_images = list(_sp.get("__group_turn_image_inputs__") or [])
+_turn_hist = list(_sp.get("__group_turn_history_attachments__") or [])
+_user_message_content = None
+if is_vision_capable(str(provider or ""), str(model or "")):
+    _user_message_content = _group_turn_image_blocks(
+        local_user_input, _turn_images, _turn_hist
+    )
+```
+
+`run_turn` **只增加**这两个可选 kwargs（其它行一字不改）：
+
+```python
+    user_message_content=_user_message_content,
+    history_user_attachments=_turn_hist or None,
+```
+
+`provider`/`model` 在 `_run_one_target` L1478–1497 已解析（Meta 用 session 模型，成员用 avatar default 再回落 session）。**按成员模型判断视觉**，不要用窗格 session 模型。
+
+`_group_turn_image_blocks`（模块级，与 `_attachments_from_image_inputs` 放一起）：
+
+```python
+def _group_turn_image_blocks(
+    user_input: str,
+    image_inputs: Sequence[Any],
+    history_attachments: Sequence[Any],
+) -> list[dict[str, Any]] | None:
+    sources: list[Mapping[str, Any]] = [
+        item for item in image_inputs if isinstance(item, Mapping)
+    ]
+    if not sources:
+        for item in history_attachments:
+            if not isinstance(item, Mapping):
+                continue
+            data_url = str(item.get("data_url") or "").strip()
+            if data_url.startswith("data:image/"):
+                sources.append(item)
+    blocks: list[dict[str, Any]] = [{"type": "text", "text": str(user_input or "")}]
+    for im in sources:
+        data_url = str(im.get("data_url") or "").strip()
+        if data_url.startswith("data:image/"):
+            blocks.append({"type": "image_url", "image_url": {"url": data_url}})
+    if len(blocks) <= 1:
+        return None
+    return blocks
+```
+
+意图：
+
+- session 非视觉时 `image_inputs` 已被 server 清空，但 `history_image_attachments` 仍在 → 视觉成员仍能从 history 重建 `image_url`。
+- 非视觉成员：`is_vision_capable` 为 False → 不传 `user_message_content`，只传 `history_user_attachments`，走 `agent_runtime.py` L3427 起已有 autodescribe / omit notice。
+- mention follow-up 的 `user_input` 可能是系统改写后的文本：`user_message_content` 的 text 块必须用 **`local_user_input`**（已含引用/系统提示），不要用原始 `user_input` 参数之外的另一份。
+- `persist_user_message` 保持默认；写入的是一次性 `local_session`，不影响群 `chat_history`。
+
+**AC-3:**
+
+- 测试名：`test_run_one_target_forwards_vision_blocks_and_attachments`
+- `_CapturingRuntime.run_turn` 把 `kwargs` 存进 `captured: dict`
+- `_make_router()` + `_session_with_workspace`
+- 调用 `_run_one_target` **之前**设：
+
+```python
+session.scratchpad = {
+    "__group_turn_image_inputs__": [
+        {"name": "image.png", "data_url": TINY_PNG, "mime_type": "image/png", "size": 70}
+    ],
+    "__group_turn_history_attachments__": [
+        {"name": "image.png", "mime_type": "image/png", "size": 70, "data_url": TINY_PNG}
+    ],
+}
+session.provider_name = "openai"
+session.model_name = "gpt-4o"
+```
+
+- `_make_router` 里 avatar 的 `default_provider`/`default_model` 保持空字符串，从而回落到 session 的 gpt-4o。
+- 断言 `captured["user_message_content"]` 是 list：第一块 `type=="text"`，其后有一块 `type=="image_url"` 且 `image_url["url"]==TINY_PNG`。
+- 断言 `captured["history_user_attachments"][0]["data_url"]==TINY_PNG`。
+
+**AC-4:**
+
+- 测试名：`test_run_one_target_non_vision_member_skips_image_blocks`
+- 同一套 capturing runtime
+- 把 `_make_router` 的 avatar `default_model` 设为已知纯文本：`glm-5`（`is_vision_capable` 对智谱文本族返回 False）
+- scratchpad 仍放 TINY_PNG
+- 断言 `captured.get("user_message_content") is None`
+- 断言 `captured["history_user_attachments"]` 仍带 `data_url`（供 autodescribe）
+
+`_make_router` 目前写死空 default_model。AC-4 不要改全局 helper 行为：在该测试里单独 `router.avatar_registry.get_avatar.return_value.default_model = "glm-5"`（MagicMock avatar 已存在）。
+
+---
+
+## FR-4：Studio 群聊把已 normalize 的图传进 router
+
+**Files:**
+
+- Modify: `agenticx/studio/server.py` — **仅** `router.run_group_turn(` 调用（约 L3211–3223）
+- Test: `tests/test_studio_server.py` — 仿 `test_group_chat_hydrates_document_before_router_turn`（约 L999）
+
+**Before:** 调用只有 `user_input=payload.user_input` 等，无图。
+
+**After:** 在 `user_display_name=u_display,` 之后、`)` 之前精确增加两行：
+
+```python
+                        image_inputs=image_inputs,
+                        history_image_attachments=history_image_attachments,
+```
+
+- `image_inputs` / `history_image_attachments` 已是 `_produce_group_events` 外层 `/api/chat` 里算好的局部变量（L2795、L2832）。不要在群聊分支重新 normalize。
+- **禁止**改 L1–100 的 import。
+- **禁止**改 L2923–2927 的非视觉清空。
+- 全文件只应出现这一处 `run_group_turn(`（可用 ripgrep 确认）。不要新增第二个调用。
+
+**AC-5:**
+
+- 测试名：`test_group_chat_forwards_image_inputs_to_router`
+- 抄 L999–1062 的 FakeGroupRouter / create_avatar / create_group 骨架
+- FakeRouter 的 `run_group_turn` 把 `kwargs.get("image_inputs")` 与 `kwargs.get("history_image_attachments")` 写入外层 `seen: dict`
+- POST `/api/chat` json 增加：
+
+```python
+"image_inputs": [
+    {
+        "name": "image.png",
+        "data_url": TINY_PNG,
+        "mime_type": "image/png",
+        "size": 70,
+    }
+],
+```
+
+`TINY_PNG` 与 FR-1 相同字符串。`ChatImageInput` 要求 `data_url` min_length=1，且 server normalize 要求 `data:image/` 前缀。
+
+- 断言 `seen["image_inputs"]` 非空，且 `[0]["data_url"]` 以 `data:image/` 开头
+- 断言 `seen["history_image_attachments"]` 非空，且 `[0]` 含 `name` / `data_url`
+- 不要断言 hydrate 顺序（本测不测文档 hydrate）
+
+新建 session 的默认模型多为未知 slug → `is_vision_capable` 为 True → `image_inputs` 不会被清空。不要依赖「必须是视觉模型」才能转发 `history_image_attachments`：即使将来默认模型变纯文本，`history_image_attachments` 仍应非空。断言以 **history** 为主，`image_inputs` 允许为空列表但不能缺 key。
+
+更稳的断言：
+
+```python
+assert "image_inputs" in seen
+assert "history_image_attachments" in seen
+assert seen["history_image_attachments"]
+assert str(seen["history_image_attachments"][0]["data_url"]).startswith("data:image/")
+```
+
+---
+
+## 实施顺序（TDD，禁止先写生产代码）
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `test-driven-development`（仓库 `.cursor/skills/test-driven-development/SKILL.md`）。每条 FR：先写失败测试 → 跑红 → 最小实现 → 跑绿。
+
+### Task 1: FR-1 append_user
+
+1. 写 `test_append_user_persists_image_attachments`
+2. `pytest tests/test_group_shared_artifact_delivery.py::test_append_user_persists_image_attachments -v` → 期望 FAIL（`append_user` unexpected keyword `attachments`）
+3. 改 `append_user`
+4. 再跑 → PASS
+
+### Task 2: FR-3 `_run_one_target`（可先于 FR-2，因读 scratchpad，不依赖 `run_group_turn` 签名）
+
+1. 写 AC-3、AC-4 两个测试
+2. `pytest tests/test_group_shared_artifact_delivery.py::test_run_one_target_forwards_vision_blocks_and_attachments tests/test_group_shared_artifact_delivery.py::test_run_one_target_non_vision_member_skips_image_blocks -v` → 期望 FAIL（kwargs 缺失或 `user_message_content` 为 None）
+3. 加 `_group_turn_image_blocks` + `_run_one_target` 两行 kwargs
+4. 再跑 → PASS
+5. 回归：`pytest tests/test_group_shared_artifact_delivery.py::test_member_prompt_mentions_shared_workspace -v` → PASS
+
+### Task 3: FR-2 `run_group_turn`
+
+1. 写 `test_run_group_turn_persists_user_image_attachments`
+2. 跑红
+3. 改签名 + stash + append_user + finally
+4. 跑绿
+
+### Task 4: FR-4 server.py
+
+1. 写 `test_group_chat_forwards_image_inputs_to_router`
+2. 跑红（kwargs 里没有这两个键，或值为 None）
+3. 只加两行 kwargs
+4. 跑绿
+5. 回归：`pytest tests/test_studio_server.py::test_group_chat_hydrates_document_before_router_turn -v`
+
+### Task 5: 回归与 server.py smoke
+
+```bash
+pytest tests/test_group_shared_artifact_delivery.py tests/test_studio_server.py::test_group_chat_hydrates_document_before_router_turn tests/test_studio_server.py::test_group_chat_forwards_image_inputs_to_router tests/test_smoke_group_mention_followup.py tests/test_smoke_group_legacy_routing.py -q
+```
+
+改了 `server.py` 后必须冷启动（仓库硬规则）：
+
+```bash
+agx serve --host 127.0.0.1 --port 18765
+# 另开终端，对 localhost 绕代理：
+curl --noproxy '*' -s -o /dev/null -w "%{http_code}" http://127.0.0.1:18765/api/session
+curl --noproxy '*' -s -o /dev/null -w "%{http_code}" http://127.0.0.1:18765/api/avatars
+curl --noproxy '*' -s -o /dev/null -w "%{http_code}" http://127.0.0.1:18765/api/sessions
+```
+
+三个都应 200。测完停掉该进程。不要占用用户正在用的 `serve.port`。
+
+---
+
+## 分支与提交
+
+- 从当前仓库开分支 `fix/group-chat-image-inputs`（不要直接在 `main` 上改）。
+- 工作区若有无关 dirty（打包脚本、examples 等），**只 add 本 plan 与本 plan 列出的代码/测试文件**。
+- 用户未要求 commit 时不要 commit。若之后要求 commit，trailer 仅允许：
+
+```
+Plan-Id: 2026-08-29-group-chat-image-inputs
+Plan-File: .cursor/plans/2026-08-29-group-chat-image-inputs.plan.md
+Plan-Model: <用户提供>
+Impl-Model: <用户提供>
+Made-with: Damon Li
+```
+
+未提供模型名则先问，禁止编造。commit subject/body 禁止第三方品牌对标，用「群聊当轮用户图片写入历史并注入成员回合」。
+
+---
+
+## 实施者自检清单
+
+- [ ] `append_user` 无 attachments 时行为与改前完全一致
+- [ ] `_run_one_target` 无 scratchpad 图时 `user_message_content` 为 None、`history_user_attachments` 为 None，与改前一致
+- [ ] mention follow-up 本轮仍能从 scratchpad 看到原图（finally 在整轮结束后才清）
+- [ ] `server.py` import 区 diff 为空
+- [ ] 未改 Desktop
+- [ ] 未改 `_call_llm_text`
+- [ ] `agx serve` 冷启动核心 API 200

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -76,7 +76,8 @@ jobs:
       - name: Stage bundled backend (arm64 / x64)
         run: |
           mkdir -p "desktop/bundled-backend/${{ matrix.arch }}"
-          cp "packaging/dist/${{ matrix.arch }}/agx-server" "desktop/bundled-backend/${{ matrix.arch }}/agx-server"
+          # onedir: 复制整个目录内容（agx-server 可执行 + _internal/）
+          cp -R "packaging/dist/${{ matrix.arch }}/agx-server/." "desktop/bundled-backend/${{ matrix.arch }}/"
           chmod +x "desktop/bundled-backend/${{ matrix.arch }}/agx-server"
           cp "packaging/wechat-sidecar/agx-wechat-sidecar" "desktop/bundled-backend/${{ matrix.arch }}/agx-wechat-sidecar"
           chmod +x "desktop/bundled-backend/${{ matrix.arch }}/agx-wechat-sidecar"
@@ -111,6 +112,7 @@ jobs:
           APP_DIR="release/mac-${{ matrix.arch }}/Near.app/Contents/Resources/backend"
           test -x "${APP_DIR}/agx-server"
           test -x "${APP_DIR}/agx-wechat-sidecar"
+          test -d "${APP_DIR}/_internal"
           echo "Verified backend binaries in ${APP_DIR}:"
           ls -l "${APP_DIR}"
 
@@ -163,8 +165,10 @@ jobs:
         run: |
           $be = "desktop/release/win-unpacked/resources/backend/agx-server.exe"
           $wx = "desktop/release/win-unpacked/resources/backend/agx-wechat-sidecar.exe"
+          $it = "desktop/release/win-unpacked/resources/backend/_internal"
           if (-not (Test-Path $be)) { throw "missing $be" }
           if (-not (Test-Path $wx)) { throw "missing $wx" }
+          if (-not (Test-Path $it)) { throw "missing $it" }
           Get-ChildItem "desktop/release/win-unpacked/resources/backend"
 
       - name: Upload artifacts
@@ -212,7 +216,8 @@ jobs:
       - name: Stage bundled backend
         run: |
           mkdir -p "desktop/bundled-backend/${{ env.ARCH }}"
-          cp "packaging/dist/${{ env.ARCH }}/agx-server" "desktop/bundled-backend/${{ env.ARCH }}/agx-server"
+          # onedir: 复制整个目录内容（agx-server 可执行 + _internal/）
+          cp -R "packaging/dist/${{ env.ARCH }}/agx-server/." "desktop/bundled-backend/${{ env.ARCH }}/"
           chmod +x "desktop/bundled-backend/${{ env.ARCH }}/agx-server"
           cp "packaging/wechat-sidecar/agx-wechat-sidecar" "desktop/bundled-backend/${{ env.ARCH }}/agx-wechat-sidecar"
           chmod +x "desktop/bundled-backend/${{ env.ARCH }}/agx-wechat-sidecar"
@@ -258,6 +263,7 @@ jobs:
           APP_DIR="release/mac-${{ env.ARCH }}/Near.app/Contents/Resources/backend"
           test -x "${APP_DIR}/agx-server"
           test -x "${APP_DIR}/agx-wechat-sidecar"
+          test -d "${APP_DIR}/_internal"
           echo "Verified backend binaries in ${APP_DIR}:"
           ls -l "${APP_DIR}"
 
@@ -310,8 +316,10 @@ jobs:
         run: |
           $be = "desktop/release/win-unpacked/resources/backend/agx-server.exe"
           $wx = "desktop/release/win-unpacked/resources/backend/agx-wechat-sidecar.exe"
+          $it = "desktop/release/win-unpacked/resources/backend/_internal"
           if (-not (Test-Path $be)) { throw "missing $be" }
           if (-not (Test-Path $wx)) { throw "missing $wx" }
+          if (-not (Test-Path $it)) { throw "missing $it" }
           Get-ChildItem "desktop/release/win-unpacked/resources/backend"
 
       - name: Upload artifacts

--- a/agenticx/__init__.py
+++ b/agenticx/__init__.py
@@ -41,7 +41,11 @@ from ._version import __version__
 __author__ = "Ziran Li"
 __email__ = "bingzhenli@hotmail.com"
 
-_IS_CLI_BOOTSTRAP = _Path(_sys.argv[0]).name in {"agx", "agenticx"}
+# Bundled Desktop entry is `agx-server` / `agx-server.exe`, not `agx`.
+# Treating it as a library import pulls GraphRAG / Neo4j / observability into
+# every cold start and is what surfaces "pip install neo4j" in the splash dialog.
+CLI_BOOTSTRAP_NAMES = frozenset({"agx", "agenticx", "agx-server", "agx-server.exe"})
+_IS_CLI_BOOTSTRAP = _Path(_sys.argv[0]).name in CLI_BOOTSTRAP_NAMES
 
 if not _IS_CLI_BOOTSTRAP:
     # 核心模块导出
@@ -188,7 +192,7 @@ if not _IS_CLI_BOOTSTRAP:
 # 主要类列表
 __all__ = [
     # 版本信息
-    "__version__", "__author__", "__email__",
+    "__version__", "__author__", "__email__", "CLI_BOOTSTRAP_NAMES",
     
     # 核心类
     "Agent", "Task", "BaseTool", "tool", "Workflow", "WorkflowNode", "WorkflowEdge",

--- a/agenticx/knowledge/graphers/__init__.py
+++ b/agenticx/knowledge/graphers/__init__.py
@@ -38,13 +38,6 @@ from .optimizer import GraphOptimizer
 # 构建器
 from .builder import KnowledgeGraphBuilder
 
-# Neo4j导出器
-try:
-    from .neo4j_exporter import Neo4jExporter, Neo4jExporterContext
-    NEO4J_AVAILABLE = True
-except ImportError:
-    NEO4J_AVAILABLE = False
-
 __all__ = [
     # 数据模型
     'EntityType',
@@ -73,11 +66,23 @@ __all__ = [
     
     # 构建器
     'KnowledgeGraphBuilder',
-    
-    # Neo4j支持
-    'NEO4J_AVAILABLE'
+
+    # Neo4j is optional and must not be imported during package init.
+    'NEO4J_AVAILABLE',
+    'Neo4jExporter',
+    'Neo4jExporterContext',
 ]
 
-# 条件导出Neo4j功能
-if NEO4J_AVAILABLE:
-    __all__.extend(['Neo4jExporter', 'Neo4jExporterContext'])
+
+def __getattr__(name: str):
+    if name == "NEO4J_AVAILABLE":
+        try:
+            from . import neo4j_exporter
+        except ImportError:
+            return False
+        return bool(getattr(neo4j_exporter, "NEO4J_AVAILABLE", False))
+    if name in {"Neo4jExporter", "Neo4jExporterContext"}:
+        from .neo4j_exporter import Neo4jExporter, Neo4jExporterContext
+
+        return Neo4jExporter if name == "Neo4jExporter" else Neo4jExporterContext
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/agenticx/knowledge/graphers/neo4j_exporter.py
+++ b/agenticx/knowledge/graphers/neo4j_exporter.py
@@ -11,8 +11,8 @@ try:
     from neo4j import GraphDatabase  # type: ignore
     NEO4J_AVAILABLE = True
 except ImportError:
+    GraphDatabase = None  # type: ignore
     NEO4J_AVAILABLE = False
-    logger.warning("Neo4j driver not available. Install with: pip install neo4j")
 
 from .models import KnowledgeGraph, Entity, Relationship, EntityType, RelationType
 

--- a/agenticx/llms/__init__.py
+++ b/agenticx/llms/__init__.py
@@ -16,7 +16,6 @@ try:  # sandbox may block SSL when importing litellm/requests
     from .minimax_provider import MiniMaxProvider
     from .deepseek_provider import DeepSeekProvider
     from .provider_resolver import ProviderResolver
-    from .llm_factory import LlmFactory
 except Exception:  # pragma: no cover
     LiteLLMProvider = None  # type: ignore
     KimiProvider = None  # type: ignore
@@ -27,7 +26,6 @@ except Exception:  # pragma: no cover
     MiniMaxProvider = None  # type: ignore
     DeepSeekProvider = None  # type: ignore
     ProviderResolver = None  # type: ignore
-    LlmFactory = None  # type: ignore
 
 from agenticx.llms.failover import FailoverProvider
 from agenticx.llms.response_cache import ResponseCache
@@ -81,6 +79,16 @@ class QianFanProvider(QianfanProvider if QianfanProvider else object):  # type: 
 class MinimaxProvider(MiniMaxProvider if MiniMaxProvider else object):  # type: ignore
     """Provider for MiniMax models."""
     pass
+
+
+def __getattr__(name: str):
+    # GraphRAG's LlmFactory imports knowledge.graphers. Keep it off the
+    # Desktop / `agx serve` cold-start path (Neo4j is optional).
+    if name == "LlmFactory":
+        from .llm_factory import LlmFactory
+
+        return LlmFactory
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = [

--- a/agenticx/llms/llm_factory.py
+++ b/agenticx/llms/llm_factory.py
@@ -2,8 +2,8 @@
 
 Author: Damon Li
 """
-from typing import cast
-from agenticx.knowledge.graphers.config import LLMConfig
+from typing import Any
+
 from .base import BaseLLMProvider
 from .litellm_provider import LiteLLMProvider
 from .kimi_provider import KimiProvider
@@ -19,7 +19,7 @@ class LlmFactory:
     """A factory for creating LLM clients."""
 
     @staticmethod
-    def create_llm(config: LLMConfig) -> BaseLLMProvider:
+    def create_llm(config: Any) -> BaseLLMProvider:
         """Create an LLM client based on the provided configuration.
 
         Args:

--- a/agenticx/llms/vision.py
+++ b/agenticx/llms/vision.py
@@ -27,11 +27,12 @@ def _minimax_m2_family_no_vision(model_name: str) -> bool:
 def _zhipu_text_only_family(model_name: str) -> bool:
     """GLM chat SKUs that reject multimodal image_url parts on BigModel v4.
 
-    Zhipu vision SKUs always carry a digit+"v" marker (glm-4v, glm-4.1v,
-    glm-4.5v, glm-4.6v, ...). Anything on the known GLM text families without
-    that marker rejects image_url and must have images stripped. Unknown model
-    names are left vision-capable to avoid wrongly stripping images from a
-    future vision SKU.
+    Older Zhipu vision SKUs carry a digit+"v" marker (glm-4v, glm-4.1v,
+    glm-4.5v, glm-4.6v, ...). The GLM-5.3 line (glm-5.3, glm-5.3-flash, ...)
+    is native multimodal without that marker and must stay vision-capable.
+    Other known GLM text families without a vision marker reject image_url
+    and must have images stripped. Unknown model names are left
+    vision-capable to avoid wrongly stripping images from a future vision SKU.
     """
     raw = str(model_name or "").strip().lower()
     if not raw:
@@ -40,6 +41,9 @@ def _zhipu_text_only_family(model_name: str) -> bool:
         raw = raw.rsplit("/", 1)[-1]
     # Vision marker -> treat as vision-capable (do not strip).
     if re.search(r"\dv|vision|vl", raw):
+        return False
+    # GLM-5.3 family is native multimodal (first GLM-5 line without a v marker).
+    if raw.startswith("glm-5.3"):
         return False
     return raw.startswith(("glm-5", "glm-4.6", "glm-4.5", "glm-4", "glm-z1", "glm-zero"))
 

--- a/agenticx/runtime/group_context.py
+++ b/agenticx/runtime/group_context.py
@@ -54,19 +54,21 @@ class GroupChatContext:
         sender_name: str = "我",
         quoted_message_id: str = "",
         quoted_content: str = "",
+        attachments: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         label = str(sender_name or "").strip() or "我"
-        self._history().append(
-            {
-                "role": "user",
-                "content": str(text or ""),
-                "sender_id": "user",
-                "sender_name": label,
-                "agent_id": "user",
-                "quoted_message_id": str(quoted_message_id or ""),
-                "quoted_content": str(quoted_content or ""),
-            }
-        )
+        row: dict[str, Any] = {
+            "role": "user",
+            "content": str(text or ""),
+            "sender_id": "user",
+            "sender_name": label,
+            "agent_id": "user",
+            "quoted_message_id": str(quoted_message_id or ""),
+            "quoted_content": str(quoted_content or ""),
+        }
+        if attachments:
+            row["attachments"] = [dict(item) for item in attachments]
+        self._history().append(row)
 
     def append_agent(
         self,

--- a/agenticx/runtime/group_router.py
+++ b/agenticx/runtime/group_router.py
@@ -36,7 +36,6 @@ from agenticx.runtime.group_facts import (
 )
 from agenticx.runtime.harden_flags import (
     group_intent_max_tokens,
-    group_meta_direct_tools_enabled,
     group_meta_reply_max_tokens,
     group_open_floor_enabled,
     group_open_floor_max_speakers,
@@ -1910,20 +1909,29 @@ class GroupChatRouter:
             yield self._typing_event(META_LEADER_AGENT_ID, self._meta_leader_label)
             if await self._should_stop(should_stop):
                 return
-            pm = await self._run_meta_project_manager_reply(
+            pm = None
+            async for pm_evt in self._run_one_target_stream(
                 base_session=base_session,
                 context=context,
+                group_id=group_id,
                 group_name=group_name,
+                avatar_id=META_LEADER_AGENT_ID,
                 user_input=user_input,
                 quoted_content=quoted_content,
+                should_stop=should_stop,
+                force_reply=True,
+                user_display_name=user_display_name,
                 extra_instruction=(
                     "用户在群里发起的是开放性提问（『群里谁能…』『哪位…』），请你以项目经理身份"
                     "**直接给出一句到三句话的核心答案**；如确实存在某位成员更适合补充细节，"
                     "可在结尾追加一行『需要 XX 的细节可以问 @某某』，不要把主答交给成员。"
                 ),
-                user_display_name=user_display_name,
-            )
-            yield pm
+            ):
+                yield pm_evt
+                if pm_evt.event_type in {"group_reply", "group_skipped"}:
+                    pm = pm_evt
+            if pm is None:
+                return
             self._record_turn_response(responded_this_turn, pm)
             async for fu in self._emit_mention_follow_ups(
                 reply=pm,
@@ -2025,48 +2033,36 @@ class GroupChatRouter:
                     + extra_instruction
                 )
             must_execute = bool(decision.requires_execution)
-            use_runtime = must_execute or group_meta_direct_tools_enabled()
-            if use_runtime:
-                pm = None
-                async for pm_evt in self._run_one_target_stream(
-                    base_session=base_session,
-                    context=context,
-                    group_id=group_id,
-                    group_name=group_name,
-                    avatar_id=META_LEADER_AGENT_ID,
-                    user_input=user_input,
-                    quoted_content=quoted_content,
-                    should_stop=should_stop,
-                    force_reply=True,
-                    user_display_name=user_display_name,
-                    extra_instruction=(
-                        _EXECUTION_TURN_INSTRUCTION if must_execute else ""
-                    ),
-                ):
-                    if (
-                        zero_exec_progress
-                        and pm_evt.event_type in {"group_reply", "group_skipped"}
-                    ):
-                        pm_evt = _append_zero_exec_fallback(pm_evt, facts)
-                    yield pm_evt
-                    if pm_evt.event_type in {"group_reply", "group_skipped"}:
-                        pm = pm_evt
-                if pm is None:
-                    return
-            else:
-                pm = await self._run_meta_project_manager_reply(
-                    base_session=base_session,
-                    context=context,
-                    group_name=group_name,
-                    user_input=user_input,
-                    quoted_content=quoted_content,
-                    extra_instruction=extra_instruction,
-                    user_display_name=user_display_name,
-                    facts=facts,
+            if must_execute:
+                extra_instruction = (
+                    f"{extra_instruction}\n{_EXECUTION_TURN_INSTRUCTION}"
+                    if extra_instruction.strip()
+                    else _EXECUTION_TURN_INSTRUCTION
                 )
-                if zero_exec_progress:
-                    pm = _append_zero_exec_fallback(pm, facts)
-                yield pm
+            pm = None
+            async for pm_evt in self._run_one_target_stream(
+                base_session=base_session,
+                context=context,
+                group_id=group_id,
+                group_name=group_name,
+                avatar_id=META_LEADER_AGENT_ID,
+                user_input=user_input,
+                quoted_content=quoted_content,
+                should_stop=should_stop,
+                force_reply=True,
+                user_display_name=user_display_name,
+                extra_instruction=extra_instruction,
+            ):
+                if (
+                    zero_exec_progress
+                    and pm_evt.event_type in {"group_reply", "group_skipped"}
+                ):
+                    pm_evt = _append_zero_exec_fallback(pm_evt, facts)
+                yield pm_evt
+                if pm_evt.event_type in {"group_reply", "group_skipped"}:
+                    pm = pm_evt
+            if pm is None:
+                return
             self._record_turn_response(responded_this_turn, pm)
             async for fu in self._emit_mention_follow_ups(
                 reply=pm,

--- a/agenticx/runtime/group_router.py
+++ b/agenticx/runtime/group_router.py
@@ -21,6 +21,7 @@ _log = logging.getLogger(__name__)
 from agenticx.avatar.registry import AvatarRegistry
 from agenticx.cli.agent_tools import STUDIO_TOOLS
 from agenticx.cli.studio import StudioSession
+from agenticx.llms.vision import is_vision_capable
 from agenticx.runtime import AgentRuntime
 from agenticx.runtime import AsyncClarifyGate, AsyncConfirmGate, ConfirmGate
 from agenticx.runtime.events import EventType
@@ -60,6 +61,58 @@ _GROUP_CONTROL_PLANE_CONTRACT = (
     "- 长代码、长报告、详细表格优先写入群工作区，最终只给摘要和产物；用户明确要求全文贴群时例外。\n"
     "- FINAL 表示本轮结束，禁止以“稍等 / 等我回复 / 我去处理”作为 FINAL。\n"
 )
+
+
+def _attachments_from_image_inputs(
+    items: Sequence[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for im in items or []:
+        if not isinstance(im, Mapping):
+            continue
+        data_url = str(im.get("data_url") or "").strip()
+        if not data_url.startswith("data:image/"):
+            continue
+        try:
+            size_val = int(im.get("size") or 0)
+        except (TypeError, ValueError):
+            size_val = 0
+        out.append(
+            {
+                "name": str(im.get("name") or "image").strip() or "image",
+                "mime_type": str(im.get("mime_type") or "image/png").strip() or "image/png",
+                "size": size_val,
+                "data_url": data_url,
+            }
+        )
+    return out
+
+
+def _group_turn_image_blocks(
+    user_input: str,
+    image_inputs: Sequence[Any],
+    history_attachments: Sequence[Any],
+) -> list[dict[str, Any]] | None:
+    sources: list[Mapping[str, Any]] = [
+        item for item in image_inputs if isinstance(item, Mapping)
+    ]
+    if not sources:
+        for item in history_attachments:
+            if not isinstance(item, Mapping):
+                continue
+            data_url = str(item.get("data_url") or "").strip()
+            if data_url.startswith("data:image/"):
+                sources.append(item)
+    blocks: list[dict[str, Any]] = [{"type": "text", "text": str(user_input or "")}]
+    for im in sources:
+        data_url = str(im.get("data_url") or "").strip()
+        if data_url.startswith("data:image/"):
+            blocks.append({"type": "image_url", "image_url": {"url": data_url}})
+    if len(blocks) <= 1:
+        return None
+    return blocks
+
+
 _EXECUTION_TURN_INSTRUCTION = (
     "这是执行请求。你必须在本轮使用必要工具实际推进；FINAL 只能汇报本轮已经发生的事实。\n"
     "禁止以“我去处理 / 稍等 / 等我回复 / 后续给你”结束本轮。"
@@ -1603,6 +1656,16 @@ class GroupChatRouter:
         final_text = ""
         error_text = ""
         successful_tool_results = 0
+        _sp = getattr(base_session, "scratchpad", None)
+        if not isinstance(_sp, dict):
+            _sp = {}
+        _turn_images = list(_sp.get("__group_turn_image_inputs__") or [])
+        _turn_hist = list(_sp.get("__group_turn_history_attachments__") or [])
+        _user_message_content = None
+        if is_vision_capable(str(provider or ""), str(model or "")):
+            _user_message_content = _group_turn_image_blocks(
+                local_user_input, _turn_images, _turn_hist
+            )
         async for event in runtime.run_turn(
             local_user_input,
             local_session,
@@ -1612,6 +1675,8 @@ class GroupChatRouter:
             system_prompt=system_prompt,
             usage_session_id=str(getattr(base_session, "_usage_owner_session_id", "") or ""),
             usage_avatar_id=str(avatar_id or ""),
+            user_message_content=_user_message_content,
+            history_user_attachments=_turn_hist or None,
         ):
             if progress_queue is not None:
                 progress_text = self._runtime_event_to_progress_text(event.type, event.data)
@@ -2667,11 +2732,59 @@ class GroupChatRouter:
         quoted_message_id: str = "",
         should_stop: Callable[[], Any],
         user_display_name: str | None = None,
+        image_inputs: Sequence[Mapping[str, Any]] | None = None,
+        history_image_attachments: Sequence[Mapping[str, Any]] | None = None,
     ) -> AsyncGenerator[GroupReply, None]:
         scratchpad = getattr(base_session, "scratchpad", None)
         if not isinstance(scratchpad, dict):
             scratchpad = {}
             setattr(base_session, "scratchpad", scratchpad)
+        turn_images = [dict(item) for item in (image_inputs or []) if isinstance(item, Mapping)]
+        turn_history = [
+            dict(item) for item in (history_image_attachments or []) if isinstance(item, Mapping)
+        ]
+        if not turn_history and turn_images:
+            turn_history = _attachments_from_image_inputs(turn_images)
+        scratchpad["__group_turn_image_inputs__"] = turn_images
+        scratchpad["__group_turn_history_attachments__"] = turn_history
+        try:
+            async for reply in self._iter_group_turn(
+                base_session=base_session,
+                scratchpad=scratchpad,
+                group_id=group_id,
+                group_name=group_name,
+                routing=routing,
+                group_avatar_ids=group_avatar_ids,
+                mentioned_avatar_ids=mentioned_avatar_ids,
+                user_input=user_input,
+                quoted_content=quoted_content,
+                quoted_message_id=quoted_message_id,
+                should_stop=should_stop,
+                user_display_name=user_display_name,
+                turn_history=turn_history,
+            ):
+                yield reply
+        finally:
+            scratchpad.pop("__group_turn_image_inputs__", None)
+            scratchpad.pop("__group_turn_history_attachments__", None)
+
+    async def _iter_group_turn(
+        self,
+        *,
+        base_session: StudioSession,
+        scratchpad: dict[str, Any],
+        group_id: str,
+        group_name: str,
+        routing: str,
+        group_avatar_ids: Sequence[str],
+        mentioned_avatar_ids: Sequence[str],
+        user_input: str,
+        quoted_content: str,
+        quoted_message_id: str,
+        should_stop: Callable[[], Any],
+        user_display_name: str | None,
+        turn_history: list[dict[str, Any]],
+    ) -> AsyncGenerator[GroupReply, None]:
         setattr(base_session, "__group_avatar_ids", list(group_avatar_ids))
         context = GroupChatContext(base_session, max_items=24)
         udn = str(user_display_name or "").strip() or "我"
@@ -2680,6 +2793,7 @@ class GroupChatRouter:
             sender_name=udn,
             quoted_message_id=quoted_message_id,
             quoted_content=quoted_content,
+            attachments=turn_history or None,
         )
         resolved_mentions = expand_mentions_with_meta_leader(
             user_input,

--- a/agenticx/studio/server.py
+++ b/agenticx/studio/server.py
@@ -3220,6 +3220,8 @@ def create_studio_app() -> FastAPI:
                         quoted_message_id=quoted_message_id,
                         should_stop=lambda: manager.should_interrupt(payload.session_id),
                         user_display_name=u_display,
+                        image_inputs=image_inputs,
+                        history_image_attachments=history_image_attachments,
                     ):
                         evt_type = str(getattr(reply, "event_type", "") or "")
                         if not evt_type:

--- a/desktop/electron/local-backend-startup.ts
+++ b/desktop/electron/local-backend-startup.ts
@@ -12,7 +12,11 @@ export const LOCAL_BACKEND_STARTUP_ENV = {
 
 export const SERVE_READY_PROBE_TIMEOUT_MS = 2_000;
 
-const DEFAULT_SERVE_STARTUP_TIMEOUT_MS = 45_000;
+// macOS/Linux 也用大预算：用户机器首次启动会叠加 Gatekeeper 全量扫描
+// (~400MB bundle) 与磁盘冷读，45s 在真实用户机器上不够（CI 自己的
+// backend smoke test 都允许 60s）。Windows 120s 的理由（杀软扫描）同样
+// 适用于 macOS 的首次 Gatekeeper 检查。
+const DEFAULT_SERVE_STARTUP_TIMEOUT_MS = 120_000;
 const WINDOWS_SERVE_STARTUP_TIMEOUT_MS = 120_000;
 
 export function getServeStartupTimeoutMs(

--- a/desktop/scripts/verify-bundled-backend.js
+++ b/desktop/scripts/verify-bundled-backend.js
@@ -28,5 +28,15 @@ exports.default = async function verifyBundledBackend(context) {
         `Run packaging/build_backend.sh and stage desktop/bundled-backend/<arch>/ before packaging.`,
     );
   }
+  // onedir layout: dependencies live next to the exe in _internal/.
+  // A bundle with the exe but without _internal/ crashes at boot.
+  const internalDir = path.join(backendDir, "_internal");
+  if (!fs.existsSync(internalDir)) {
+    throw new Error(
+      `[afterPack] Bundled backend _internal/ missing: ${internalDir}\n` +
+        `The agx-server exe was staged without its onedir dependencies.\n` +
+        `Re-run packaging/build_backend.sh (onedir mode) and stage the whole directory.`,
+    );
+  }
   console.log(`[afterPack] Verified bundled backend: ${binary}`);
 };

--- a/desktop/src/utils/model-vision.test.ts
+++ b/desktop/src/utils/model-vision.test.ts
@@ -8,6 +8,15 @@ describe("isKnownNonVisionChatModel — zhipu GLM text vs vision", () => {
     expect(isKnownNonVisionChatModel("zhipu", "glm-4.6")).toBe(true);
     expect(isKnownNonVisionChatModel("zhipu", "glm-4-plus")).toBe(true);
     expect(isKnownNonVisionChatModel("zhipu", "glm-5")).toBe(true);
+    expect(isKnownNonVisionChatModel("zhipu", "glm-5.2")).toBe(true);
+  });
+
+  it("treats GLM-5.3 Flash as vision-capable", () => {
+    expect(isKnownNonVisionChatModel("zhipu", "glm-5.3-flash")).toBe(false);
+    expect(isKnownNonVisionChatModel("zhipu", "GLM-5.3-Flash")).toBe(false);
+    expect(isKnownNonVisionChatModel("zhipu", "openai/glm-5.3-flash")).toBe(false);
+    expect(isKnownNonVisionChatModel("custom_openai_x", "glm-5.3-flash")).toBe(false);
+    expect(isKnownNonVisionChatModel("zhipu", "glm-5.3")).toBe(false);
   });
 
   it("treats known text-only SKUs as non-vision on custom OpenAI gateways", () => {

--- a/desktop/src/utils/model-vision.ts
+++ b/desktop/src/utils/model-vision.ts
@@ -18,10 +18,11 @@ function minimaxM2TextOnlySlug(slug: string): boolean {
   return false;
 }
 
-/** Zhipu GLM text SKUs (no digit+"v" vision marker) reject image_url on paas v4. */
+/** Zhipu GLM text SKUs (no digit+"v" / GLM-5.3 multimodal line) reject image_url on paas v4. */
 function zhipuTextOnlySlug(slug: string): boolean {
   const s = slug.toLowerCase();
   if (/\dv|vision|vl/.test(s)) return false;
+  if (s.startsWith("glm-5.3")) return false;
   return /^glm-(5|4\.6|4\.5|4|z1|zero)/.test(s);
 }
 

--- a/desktop/tests/local-backend-startup.test.ts
+++ b/desktop/tests/local-backend-startup.test.ts
@@ -13,10 +13,10 @@ describe("local backend startup stopgap", () => {
     });
   });
 
-  it("allows a slower Windows cold start without changing other platforms", () => {
+  it("allows a slower cold start on every platform (Gatekeeper / antivirus first-launch scans)", () => {
     expect(getServeStartupTimeoutMs("win32")).toBe(120_000);
-    expect(getServeStartupTimeoutMs("darwin")).toBe(45_000);
-    expect(getServeStartupTimeoutMs("linux")).toBe(45_000);
+    expect(getServeStartupTimeoutMs("darwin")).toBe(120_000);
+    expect(getServeStartupTimeoutMs("linux")).toBe(120_000);
   });
 
   it("bounds each readiness request so probes cannot hang indefinitely", () => {

--- a/packaging/build_backend.sh
+++ b/packaging/build_backend.sh
@@ -81,19 +81,27 @@ PY
 
 cd "$PY_DIR"
 
+# 清理旧产物：onefile 时代的单文件 agx-server 与 onedir 目录同名冲突
+rm -rf "$DIST_DIR/agx-server"
+
 "$VPY" -m PyInstaller agx_serve.spec \
   --distpath "$DIST_DIR" \
   --workpath "$WORK_DIR" \
   --clean \
   --noconfirm
 
-BINARY="$DIST_DIR/agx-server"
+# onedir 产物：dist/<arch>/agx-server/agx-server（可执行）+ _internal/（依赖）
+BINARY="$DIST_DIR/agx-server/agx-server"
 if [[ ! -x "$BINARY" ]]; then
   echo "✗ Expected binary not found or not executable: $BINARY"
   exit 1
 fi
+if [[ ! -d "$DIST_DIR/agx-server/_internal" ]]; then
+  echo "✗ Expected onedir _internal/ not found: $DIST_DIR/agx-server/_internal"
+  exit 1
+fi
 
-echo "=== Built: $BINARY ($(du -sh "$BINARY" | cut -f1)) ==="
+echo "=== Built: $BINARY ($(du -sh "$DIST_DIR/agx-server" | cut -f1) onedir bundle) ==="
 
 echo "=== Bundled runtime dependency check ==="
 "$BINARY" --check-desktop-runtime

--- a/packaging/build_dmg.sh
+++ b/packaging/build_dmg.sh
@@ -23,23 +23,54 @@ echo "=== Building Machi ($ARCH) ==="
 
 copy_arm64() {
   mkdir -p "$DESKTOP_DIR/bundled-backend/arm64"
-  cp "$SCRIPT_DIR/dist/arm64/agx-server" "$DESKTOP_DIR/bundled-backend/arm64/agx-server"
+  # onedir: 可执行 + _internal/ 一起平铺
+  cp -R "$SCRIPT_DIR/dist/arm64/agx-server/." "$DESKTOP_DIR/bundled-backend/arm64/"
   chmod +x "$DESKTOP_DIR/bundled-backend/arm64/agx-server"
 }
 
 copy_x64() {
   mkdir -p "$DESKTOP_DIR/bundled-backend/x64"
-  cp "$SCRIPT_DIR/dist/x64/agx-server" "$DESKTOP_DIR/bundled-backend/x64/agx-server"
+  cp -R "$SCRIPT_DIR/dist/x64/agx-server/." "$DESKTOP_DIR/bundled-backend/x64/"
   chmod +x "$DESKTOP_DIR/bundled-backend/x64/agx-server"
 }
 
+# 合并双侧 Mach-O（_internal 里的 .dylib/.so 分架构），非 Mach-O 保留基底侧。
+_merge_universal_file() {
+  local base="$1" other="$2"
+  local archs_base archs_other
+  archs_base="$(lipo -archs "$base" 2>/dev/null || true)"
+  archs_other="$(lipo -archs "$other" 2>/dev/null || true)"
+  [[ -z "$archs_base" || -z "$archs_other" ]] && return 2  # 非 Mach-O，保留 base
+  for arch in $archs_other; do
+    [[ " $archs_base " == *" $arch "* ]] && return 2  # 架构已包含，跳过
+  done
+  lipo -create "$base" "$other" -output "$base.universal" 2>/dev/null \
+    && mv "$base.universal" "$base" \
+    || rm -f "$base.universal"
+}
+
 copy_universal() {
-  mkdir -p "$DESKTOP_DIR/bundled-backend/universal"
+  local dst="$DESKTOP_DIR/bundled-backend/universal"
+  local a_int="$SCRIPT_DIR/dist/arm64/agx-server/_internal"
+  local x_int="$SCRIPT_DIR/dist/x64/agx-server/_internal"
+  mkdir -p "$dst"
   lipo -create \
-    "$SCRIPT_DIR/dist/arm64/agx-server" \
-    "$SCRIPT_DIR/dist/x64/agx-server" \
-    -output "$DESKTOP_DIR/bundled-backend/universal/agx-server"
-  chmod +x "$DESKTOP_DIR/bundled-backend/universal/agx-server"
+    "$SCRIPT_DIR/dist/arm64/agx-server/agx-server" \
+    "$SCRIPT_DIR/dist/x64/agx-server/agx-server" \
+    -output "$dst/agx-server"
+  chmod +x "$dst/agx-server"
+  # _internal 基底用 arm64 侧，再从 x64 侧补齐/合并
+  cp -R "$a_int/." "$dst/_internal/"
+  while IFS= read -r -d '' rel; do
+    local base="$dst/_internal/$rel"
+    local other="$x_int/$rel"
+    if [[ ! -f "$base" ]]; then
+      mkdir -p "$(dirname "$base")"
+      cp "$other" "$base"
+    else
+      _merge_universal_file "$base" "$other"
+    fi
+  done < <(cd "$x_int" && find . -type f ! -name '.DS_Store' -print0)
 }
 
 if [[ -z "$SKIP_BACKEND" ]]; then
@@ -62,20 +93,20 @@ if [[ -z "$SKIP_BACKEND" ]]; then
 else
   echo "--- Step 1: Skipping backend build (SKIP_BACKEND=1) ---"
   if [[ "$ARCH" == "universal" ]]; then
-    if [[ ! -f "$SCRIPT_DIR/dist/arm64/agx-server" || ! -f "$SCRIPT_DIR/dist/x64/agx-server" ]]; then
-      echo "✗ Need packaging/dist/arm64 and x64/agx-server when using SKIP_BACKEND with universal"
+    if [[ ! -f "$SCRIPT_DIR/dist/arm64/agx-server/agx-server" || ! -f "$SCRIPT_DIR/dist/x64/agx-server/agx-server" ]]; then
+      echo "✗ Need packaging/dist/{arm64,x64}/agx-server/agx-server when using SKIP_BACKEND with universal"
       exit 1
     fi
     copy_universal
   elif [[ "$ARCH" == "arm64" ]]; then
-    if [[ ! -f "$SCRIPT_DIR/dist/arm64/agx-server" ]]; then
-      echo "✗ Missing packaging/dist/arm64/agx-server"
+    if [[ ! -f "$SCRIPT_DIR/dist/arm64/agx-server/agx-server" ]]; then
+      echo "✗ Missing packaging/dist/arm64/agx-server/agx-server"
       exit 1
     fi
     copy_arm64
   else
-    if [[ ! -f "$SCRIPT_DIR/dist/x64/agx-server" ]]; then
-      echo "✗ Missing packaging/dist/x64/agx-server"
+    if [[ ! -f "$SCRIPT_DIR/dist/x64/agx-server/agx-server" ]]; then
+      echo "✗ Missing packaging/dist/x64/agx-server/agx-server"
       exit 1
     fi
     copy_x64

--- a/packaging/build_windows_installer.ps1
+++ b/packaging/build_windows_installer.ps1
@@ -158,7 +158,9 @@ print("desktop-runtime dependency import check passed")
     }
 }
 
-$ExePath = Join-Path $DistArchDir 'agx-server.exe'
+# onedir 产物：dist\win-amd64\agx-server\agx-server.exe + agx-server\_internal\
+$OnedirDir = Join-Path $DistArchDir 'agx-server'
+$ExePath = Join-Path $OnedirDir 'agx-server.exe'
 $HaveCachedBackend = Test-Path $ExePath
 
 if (-not $SkipPyInstaller) {
@@ -175,6 +177,9 @@ if (-not $SkipPyInstaller) {
 
     New-Item -ItemType Directory -Force -Path $DistArchDir | Out-Null
     New-Item -ItemType Directory -Force -Path $WorkArchDir | Out-Null
+    # 清理旧产物：onefile 时代的单文件 agx-server.exe 与 onedir 目录同名冲突
+    if (Test-Path $OnedirDir) { Remove-Item -Recurse -Force $OnedirDir }
+    if (Test-Path (Join-Path $DistArchDir 'agx-server.exe')) { Remove-Item -Force (Join-Path $DistArchDir 'agx-server.exe') }
 
     Push-Location $PyDir
     try {
@@ -189,6 +194,9 @@ if (-not $SkipPyInstaller) {
 
     if (-not (Test-Path $ExePath)) {
         Write-Error "Expected agx-server.exe not found: $ExePath"
+    }
+    if (-not (Test-Path (Join-Path $OnedirDir '_internal'))) {
+        Write-Error "Expected onedir _internal\ not found: $(Join-Path $OnedirDir '_internal')"
     }
 }
 else {
@@ -252,7 +260,11 @@ if (-not (Test-Path $SidecarExe)) {
 
 Write-Host '--- Step 3: Stage desktop/bundled-backend/win-amd64 ---'
 New-Item -ItemType Directory -Force -Path $BundledDir | Out-Null
-Copy-Item -Path $ExePath -Destination (Join-Path $BundledDir 'agx-server.exe') -Force
+# onedir staging: 把 agx-server.exe + _internal\ 平铺进 bundled-backend\win-amd64\
+Copy-Item -Path (Join-Path $OnedirDir '*') -Destination $BundledDir -Recurse -Force
+if (-not (Test-Path (Join-Path $BundledDir '_internal'))) {
+    Write-Error "Staging incomplete: $BundledDir\_internal missing after Copy-Item"
+}
 Copy-Item -Path $SidecarExe -Destination (Join-Path $BundledDir 'agx-wechat-sidecar.exe') -Force
 
 Write-Host '--- Step 4: npm ci + desktop build ---'

--- a/packaging/pyinstaller/agx_serve.spec
+++ b/packaging/pyinstaller/agx_serve.spec
@@ -134,17 +134,30 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
+# NOTE: onedir（COLLECT）而非 onefile。onefile 模式下 bootloader 每次
+# 启动都要把整个 ~400MB bundle 解压到 /tmp 临时目录再运行——桌面端
+# "agx serve startup timeout after 45s" 的主因就是用户机器上首次
+# 启动叠加 Gatekeeper 扫描 + onefile 解压远超 45 秒（CI 自己的 smoke
+# test 都要等 60s）。onedir 直接从磁盘 mmap 运行，冷启动时间大幅缩短。
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
+    exclude_binaries=True,
     name="agx-server",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=False,
     console=True,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="agx-server",
 )

--- a/packaging/pyinstaller/agx_serve_entry.py
+++ b/packaging/pyinstaller/agx_serve_entry.py
@@ -11,11 +11,27 @@ import ctypes
 import importlib
 import os
 import sys
+import time
 
 # LiteLLM otherwise tries to refresh optional model-pricing metadata from
 # GitHub during import. The bundled Desktop must boot from the packaged backup
 # even when public-network access is slow, filtered, or completely unavailable.
 os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "true"
+
+
+def _log_stage(msg: str) -> None:
+    """Emit a startup timeline marker to stderr.
+
+    The Electron launcher buffers stderr and prints the tail when the backend
+    fails to become ready in time — stage markers pinpoint which step hung
+    instead of showing only the last library warning.
+    """
+    elapsed = time.monotonic() - _START_T0
+    print(f"[agx-server {elapsed:7.1f}s] {msg}", file=sys.stderr, flush=True)
+
+
+_START_T0 = time.monotonic()
+_log_stage(f"bootloader handoff complete (argv={' '.join(sys.argv[1:])})")
 
 
 def _suppress_macos_dock_icon() -> None:
@@ -119,10 +135,20 @@ def main() -> None:
 
     _suppress_macos_dock_icon()
 
+    # `agx-server` is a CLI bootstrap name so agenticx/__init__ does not dump
+    # GraphRAG / Neo4j / observability into every cold start. Core must be
+    # imported first, otherwise studio → tools.base → core/__init__ hits a
+    # circular import with agent_executor.
+    _log_stage("importing agenticx.core")
+    import agenticx.core  # noqa: F401
+    _log_stage("importing agenticx.studio.server (heavy import chain)")
     from agenticx.studio.server import create_studio_app
     import uvicorn
+    _log_stage("studio server module imported")
 
     app = create_studio_app()
+    _log_stage("create_studio_app() done, starting uvicorn")
+
     uvicorn.run(app, host=args.host, port=args.port)
 
 

--- a/tests/test_desktop_startup_stopgap.py
+++ b/tests/test_desktop_startup_stopgap.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -23,3 +25,81 @@ def test_bundled_server_forces_litellm_local_cost_map(monkeypatch) -> None:
     )
 
     assert os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] == "true"
+
+
+def test_cli_bootstrap_names_include_bundled_server() -> None:
+    from agenticx import CLI_BOOTSTRAP_NAMES
+
+    assert "agx-server" in CLI_BOOTSTRAP_NAMES
+    assert "agx-server.exe" in CLI_BOOTSTRAP_NAMES
+
+
+def _run_fresh_python(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{REPO_ROOT}{os.pathsep}{existing}" if existing else str(REPO_ROOT)
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_provider_resolver_import_skips_neo4j_exporter() -> None:
+    result = _run_fresh_python(
+        "\n".join(
+            [
+                "import sys",
+                "from agenticx.llms.provider_resolver import ProviderResolver",
+                "assert ProviderResolver is not None",
+                "assert 'agenticx.knowledge.graphers.neo4j_exporter' not in sys.modules",
+                "assert 'agenticx.knowledge.graphers' not in sys.modules",
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_bundled_server_argv_skips_eager_framework_import() -> None:
+    result = _run_fresh_python(
+        "\n".join(
+            [
+                "import sys",
+                "sys.argv[0] = 'agx-server'",
+                "import agenticx",
+                "assert 'agenticx.knowledge.graphers.neo4j_exporter' not in sys.modules",
+                "assert 'agenticx.core' not in sys.modules",
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_bundled_entry_import_order_skips_neo4j_exporter() -> None:
+    result = _run_fresh_python(
+        "\n".join(
+            [
+                "import sys",
+                "sys.argv[0] = 'agx-server'",
+                "import agenticx.core",
+                "from agenticx.studio.server import create_studio_app",
+                "assert create_studio_app is not None",
+                "assert 'agenticx.knowledge.graphers.neo4j_exporter' not in sys.modules",
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_neo4j_exporter_import_does_not_warn_without_driver() -> None:
+    result = _run_fresh_python(
+        "from agenticx.knowledge.graphers.neo4j_exporter import NEO4J_AVAILABLE, Neo4jExporter"
+    )
+    assert result.returncode == 0, result.stderr
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert "pip install neo4j" not in combined
+    assert "Neo4j driver not available" not in combined

--- a/tests/test_group_shared_artifact_delivery.py
+++ b/tests/test_group_shared_artifact_delivery.py
@@ -32,6 +32,11 @@ from agenticx.runtime.group_router import (
 from agenticx.studio.session_manager import ManagedSession, SessionManager
 from agenticx.workspace.loader import ensure_group_workspace
 
+TINY_PNG = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
 
 def _patch_agenticx_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     home = tmp_path / ".agenticx"
@@ -362,6 +367,26 @@ def test_append_agent_attachments_match_session_schema() -> None:
     assert "attachments" not in session.chat_history[-1]
 
 
+def test_append_user_persists_image_attachments() -> None:
+    session = SimpleNamespace(chat_history=[], scratchpad={})
+    context = GroupChatContext(session)
+    context.append_user(
+        "看这张图",
+        attachments=[
+            {
+                "name": "image.png",
+                "mime_type": "image/png",
+                "size": 12,
+                "data_url": TINY_PNG,
+            }
+        ],
+    )
+    assert session.chat_history[-1]["attachments"][0]["data_url"].startswith("data:image/")
+    assert session.chat_history[-1]["attachments"][0]["name"] == "image.png"
+    context.append_user("纯文字")
+    assert "attachments" not in session.chat_history[-1]
+
+
 def test_sse_payload_includes_artifacts() -> None:
     reply = GroupReply(
         agent_id="a1",
@@ -427,6 +452,157 @@ async def test_member_prompt_mentions_shared_workspace(
     assert "群共享工作区" in captured[0]
     assert str(root) in captured[0]
     assert "不要伪造路径" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_run_one_target_forwards_vision_blocks_and_attachments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _CapturingRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def run_turn(self, *args, **kwargs):
+            captured.update(kwargs)
+            yield SimpleNamespace(type=EventType.FINAL.value, data={"text": "看到图了。"})
+
+    monkeypatch.setattr("agenticx.runtime.group_router.AgentRuntime", _CapturingRuntime)
+    router = _make_router()
+    root = tmp_path / "ws"
+    root.mkdir()
+    session = _session_with_workspace(root)
+    session.provider_name = "openai"
+    session.model_name = "gpt-4o"
+    session.scratchpad = {
+        "__group_turn_image_inputs__": [
+            {"name": "image.png", "data_url": TINY_PNG, "mime_type": "image/png", "size": 70}
+        ],
+        "__group_turn_history_attachments__": [
+            {"name": "image.png", "mime_type": "image/png", "size": 70, "data_url": TINY_PNG}
+        ],
+    }
+    await router._run_one_target(
+        base_session=session,
+        context=GroupChatContext(session),
+        group_id="g1",
+        group_name="Room",
+        avatar_id="a1",
+        user_input="看图",
+        quoted_content="",
+        should_stop=lambda: False,
+        force_reply=True,
+    )
+    content = captured.get("user_message_content")
+    assert isinstance(content, list)
+    assert content[0]["type"] == "text"
+    assert content[0]["text"] == "看图"
+    image_blocks = [block for block in content if block.get("type") == "image_url"]
+    assert image_blocks
+    assert image_blocks[0]["image_url"]["url"] == TINY_PNG
+    history = captured.get("history_user_attachments")
+    assert isinstance(history, list)
+    assert history[0]["data_url"] == TINY_PNG
+
+
+@pytest.mark.asyncio
+async def test_run_one_target_non_vision_member_skips_image_blocks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _CapturingRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def run_turn(self, *args, **kwargs):
+            captured.update(kwargs)
+            yield SimpleNamespace(type=EventType.FINAL.value, data={"text": "纯文本。"})
+
+    monkeypatch.setattr("agenticx.runtime.group_router.AgentRuntime", _CapturingRuntime)
+    router = _make_router()
+    router.avatar_registry.get_avatar.return_value.default_model = "glm-5"
+    root = tmp_path / "ws"
+    root.mkdir()
+    session = _session_with_workspace(root)
+    session.scratchpad = {
+        "__group_turn_image_inputs__": [
+            {"name": "image.png", "data_url": TINY_PNG, "mime_type": "image/png", "size": 70}
+        ],
+        "__group_turn_history_attachments__": [
+            {"name": "image.png", "mime_type": "image/png", "size": 70, "data_url": TINY_PNG}
+        ],
+    }
+    await router._run_one_target(
+        base_session=session,
+        context=GroupChatContext(session),
+        group_id="g1",
+        group_name="Room",
+        avatar_id="a1",
+        user_input="看图",
+        quoted_content="",
+        should_stop=lambda: False,
+        force_reply=True,
+    )
+    assert captured.get("user_message_content") is None
+    history = captured.get("history_user_attachments")
+    assert isinstance(history, list)
+    assert history[0]["data_url"] == TINY_PNG
+
+
+@pytest.mark.asyncio
+async def test_run_group_turn_persists_user_image_attachments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CapturingRuntime:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def run_turn(self, *args, **kwargs):
+            yield SimpleNamespace(type=EventType.FINAL.value, data={"text": "看到图了。"})
+
+    monkeypatch.setattr("agenticx.runtime.group_router.AgentRuntime", _CapturingRuntime)
+    router = _make_router()
+    root = tmp_path / "ws"
+    root.mkdir()
+    session = _session_with_workspace(root)
+    session.provider_name = "openai"
+    session.model_name = "gpt-4o"
+    image = {
+        "name": "image.png",
+        "data_url": TINY_PNG,
+        "mime_type": "image/png",
+        "size": 70,
+    }
+    history = {
+        "name": "image.png",
+        "mime_type": "image/png",
+        "size": 70,
+        "data_url": TINY_PNG,
+    }
+    async for _ in router.run_group_turn(
+        base_session=session,
+        group_id="g1",
+        group_name="Room",
+        routing="user-directed",
+        group_avatar_ids=["a1"],
+        mentioned_avatar_ids=["a1"],
+        user_input="看图",
+        quoted_content="",
+        should_stop=lambda: False,
+        image_inputs=[image],
+        history_image_attachments=[history],
+    ):
+        pass
+    user_rows = [row for row in session.chat_history if row.get("role") == "user"]
+    assert user_rows
+    assert user_rows[0]["attachments"][0]["data_url"] == TINY_PNG
+    assert "__group_turn_image_inputs__" not in session.scratchpad
+    assert "__group_turn_history_attachments__" not in session.scratchpad
 
 
 def test_ensure_group_workspace_is_stable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_llm_vision.py
+++ b/tests/test_llm_vision.py
@@ -28,6 +28,15 @@ def test_zhipu_text_only_glm_skus_are_not_vision_capable() -> None:
     assert is_vision_capable("zhipu", "glm-4.6") is False
     assert is_vision_capable("zhipu", "glm-4-plus") is False
     assert is_vision_capable("zhipu", "glm-5") is False
+    assert is_vision_capable("zhipu", "glm-5.2") is False
+
+
+def test_zhipu_glm53_flash_is_vision_capable() -> None:
+    assert is_vision_capable("zhipu", "glm-5.3-flash") is True
+    assert is_vision_capable("zhipu", "GLM-5.3-Flash") is True
+    assert is_vision_capable("zhipu", "openai/glm-5.3-flash") is True
+    assert is_vision_capable("custom_openai_x", "glm-5.3-flash") is True
+    assert is_vision_capable("zhipu", "glm-5.3") is True
 
 
 def test_known_text_only_skus_are_not_vision_capable_across_providers() -> None:

--- a/tests/test_smoke_group_control_plane.py
+++ b/tests/test_smoke_group_control_plane.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Smoke tests: group-chat floor control, short-reply contract, evidence gate.
 
-钉住控制室发言权：单人专业答、执行型 Near 走 runtime、静默 skip、
+钉住控制室发言权：单人专业答、未 @ / 执行型 Near 主答走 runtime、静默 skip、
 无公开催人、无证据不得声称完成。
 
 Author: Damon Li
@@ -303,13 +303,7 @@ async def test_open_floor_still_allows_two_candidates() -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_execution_meta_direct_uses_runtime_when_flag_off(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "agenticx.runtime.group_router.group_meta_direct_tools_enabled",
-        lambda: False,
-    )
+async def test_execution_meta_direct_uses_runtime() -> None:
     router = _make_router_with_spies(["a1", "a2"])
     stream_order: list[str] = []
     extra_instructions: list[str] = []
@@ -339,51 +333,28 @@ async def test_execution_meta_direct_uses_runtime_when_flag_off(
 
 
 @pytest.mark.asyncio
-async def test_casual_meta_direct_still_uses_pm_when_flag_off(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "agenticx.runtime.group_router.group_meta_direct_tools_enabled",
-        lambda: False,
-    )
+async def test_casual_meta_direct_uses_runtime() -> None:
     router = _make_router_with_spies(["a1", "a2"])
     stream_order: list[str] = []
     extra_instructions: list[str] = []
-    _install_turn_stubs(
-        router,
-        decision=IntentDecision("meta_direct", [], "pm"),
-        stream_by_id={},
-        meta_reply=_reply(META_LEADER_AGENT_ID, "这是概念解释。"),
-        stream_order=stream_order,
-        extra_instructions=extra_instructions,
-    )
-    events = await _collect_turn(router, avatar_ids=["a1", "a2"])
-    assert stream_order == []
-    assert extra_instructions
-    replies = [e for e in events if e.event_type == "group_reply"]
-    assert replies[-1].content == "这是概念解释。"
-
-
-@pytest.mark.asyncio
-async def test_meta_direct_tools_flag_still_uses_runtime(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        "agenticx.runtime.group_router.group_meta_direct_tools_enabled",
-        lambda: True,
-    )
-    router = _make_router_with_spies(["a1", "a2"])
-    stream_order: list[str] = []
+    stream_kwargs: list[dict] = []
     _install_turn_stubs(
         router,
         decision=IntentDecision("meta_direct", [], "pm"),
         stream_by_id={
-            META_LEADER_AGENT_ID: _reply(META_LEADER_AGENT_ID, "我来答。"),
+            META_LEADER_AGENT_ID: _reply(META_LEADER_AGENT_ID, "这是概念解释。"),
         },
         stream_order=stream_order,
+        extra_instructions=extra_instructions,
+        stream_kwargs=stream_kwargs,
     )
-    await _collect_turn(router, avatar_ids=["a1", "a2"])
+    events = await _collect_turn(router, avatar_ids=["a1", "a2"])
     assert stream_order == [META_LEADER_AGENT_ID]
+    assert extra_instructions == []
+    assert stream_kwargs
+    assert "项目经理" in str(stream_kwargs[0].get("extra_instruction") or "")
+    replies = [e for e in events if e.event_type == "group_reply"]
+    assert replies[-1].content == "这是概念解释。"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_group_mention_followup.py
+++ b/tests/test_smoke_group_mention_followup.py
@@ -142,7 +142,8 @@ async def test_near_meta_direct_at_member_starts_followup() -> None:
     async def _stub_stream(**kwargs):
         aid = str(kwargs.get("avatar_id") or "")
         stream_order.append(aid)
-        yield _reply(aid, "相关行已贴出。")
+        content = NEAR_ASSIGNMENT if aid == META_LEADER_AGENT_ID else "相关行已贴出。"
+        yield _reply(aid, content)
 
     async def _stub_meta(**kwargs):
         return GroupReply(

--- a/tests/test_smoke_group_workforce_bridge.py
+++ b/tests/test_smoke_group_workforce_bridge.py
@@ -431,7 +431,8 @@ class TestRoutingDispatch:
         """Broadcast questions like '群里谁能…' should be answered by Machi, not single-routed to a member."""
         router = _make_router()
         analyze_called = False
-        meta_called = False
+        runtime_called = False
+        pm_called = False
 
         async def stub_analyze_intent(**kwargs):
             nonlocal analyze_called
@@ -440,14 +441,28 @@ class TestRoutingDispatch:
             return IntentDecision(action="route_to", target_ids=["av1"], reason="stub")
 
         async def stub_meta_pm(**kwargs):
-            nonlocal meta_called
-            meta_called = True
+            nonlocal pm_called
+            pm_called = True
             return GroupReply(
-                "__meta__", "Machi", "", "Machi 答", False, event_type="group_reply"
+                "__meta__", "Machi", "", "text-pm", False, event_type="group_reply"
+            )
+
+        async def stub_one_target_stream(**kwargs):
+            nonlocal runtime_called
+            if kwargs.get("avatar_id") == "__meta__":
+                runtime_called = True
+            yield GroupReply(
+                kwargs.get("avatar_id", "__meta__"),
+                "Machi",
+                "",
+                "Machi 答",
+                False,
+                event_type="group_reply",
             )
 
         router._analyze_intent = stub_analyze_intent  # type: ignore[assignment]
         router._run_meta_project_manager_reply = stub_meta_pm  # type: ignore[assignment]
+        router._run_one_target_stream = stub_one_target_stream  # type: ignore[assignment]
 
         session = _make_session()
         replies = []
@@ -464,7 +479,8 @@ class TestRoutingDispatch:
         ):
             replies.append(r)
 
-        assert meta_called, "Open-call question should route to Machi (meta PM)"
+        assert runtime_called, "Open-call question should route to Near runtime"
+        assert not pm_called, "Open-call Near reply must not use text-only PM"
         assert not analyze_called, (
             "Open-call detector must run BEFORE _analyze_intent; "
             "otherwise we'd silently single-target a member."

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -1062,6 +1062,73 @@ def test_group_chat_hydrates_document_before_router_turn(monkeypatch, tmp_path) 
     assert seen_context.get(str(pdf)) == "GROUP_HYDRATED"
 
 
+def test_group_chat_forwards_image_inputs_to_router(monkeypatch) -> None:
+    from agenticx.runtime.group_router import GroupReply
+    from agenticx.studio import server as server_module
+
+    tiny_png = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+    monkeypatch.setattr(server_module.ProviderResolver, "resolve", lambda **_kwargs: _TextLLM())
+    seen: Dict[str, Any] = {}
+
+    class _FakeGroupRouter:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def pick_targets(self, **_kwargs):
+            return ["meta"]
+
+        def _plain_targets_in_text(self, *_args, **_kwargs):
+            return []
+
+        async def run_group_turn(self, **kwargs):
+            seen["image_inputs"] = kwargs.get("image_inputs")
+            seen["history_image_attachments"] = kwargs.get("history_image_attachments")
+            yield GroupReply(
+                agent_id="meta",
+                avatar_name="Machi",
+                avatar_url="",
+                content="group done",
+                skipped=False,
+                event_type="group_reply",
+            )
+
+    monkeypatch.setattr(server_module, "GroupChatRouter", _FakeGroupRouter)
+
+    app = create_studio_app()
+    client = TestClient(app)
+    avatar_registry = app.state.avatar_registry
+    group_registry = app.state.group_registry
+    session_id = client.get("/api/session").json()["session_id"]
+    avatar = avatar_registry.create_avatar(name="测试成员", role="Engineer")
+    group = group_registry.create_group(name="测试群", avatar_ids=[avatar.id], routing="intelligent")
+
+    resp = client.post(
+        "/api/chat",
+        json={
+            "session_id": session_id,
+            "group_id": group.id,
+            "user_input": "看这张图",
+            "image_inputs": [
+                {
+                    "name": "image.png",
+                    "data_url": tiny_png,
+                    "mime_type": "image/png",
+                    "size": 70,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    _ = _extract_events(resp.text.splitlines())
+    assert "image_inputs" in seen
+    assert "history_image_attachments" in seen
+    assert seen["history_image_attachments"]
+    assert str(seen["history_image_attachments"][0]["data_url"]).startswith("data:image/")
+
+
 def test_chat_does_not_hydrate_plain_context_twice(monkeypatch, tmp_path) -> None:
     from agenticx.studio import server as server_module
 


### PR DESCRIPTION
## Summary
- Persist uploaded images on group-chat user turns and inject them into member runtimes
- Treat GLM-5.3 Flash as vision-capable so images are not stripped
- Un-@ Near answers use the same runtime as an explicit @Near (vision + tools)
- Keep optional graph extras off Desktop cold start

## Test plan
- [ ] Fully quit Desktop and restart `agx serve`
- [ ] In a group, send an image without @Near and confirm the reply uses the picture
- [ ] Confirm casual group routing still lets members skip / pick up naturally
- [ ] Confirm Desktop cold start does not require optional graph extras