### PR TITLE
feat(reliability): add SDK crash-resume kernel and fail-closed defaults

### DIFF
--- a/.cursor/plans/2026-09-12-sdk-reliability-01-call-identity.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-01-call-identity.plan.md
@@ -1,0 +1,428 @@
+---
+name: sdk-reliability-01-call-identity
+overview: 新建 agenticx/reliability/ 可靠性内核的第一块基石——工具调用的规范身份与幂等账本。当前 AgenticX 全仓没有任何「这次工具调用是不是上次那一次」的概念（rg fingerprint 的命中全是前缀缓存/入库缓存/循环检测的无关指纹），导致崩溃恢复只能靠 interrupted_closers 塞一句「结果未知，你自己去核验」把幂等判断外包给 LLM。本 Subplan 交付 canonical_call_key() 参数规范化、CallLedger JSONL 账本、以及 reconcile() 四态判决（FRESH / REPLAY_SKIP / AMBIGUOUS / IDENTITY_CONFLICT），为 02（SDK 续跑）与 03（重放策略）提供确定性依据。纯新增模块，不改任何既有文件。
+todos:
+  - id: t1
+    content: 新建 agenticx/reliability/ 包骨架与 errors.py
+    status: pending
+  - id: t2
+    content: 实现 call_identity.py 的 canonical_call_key()
+    status: pending
+  - id: t3
+    content: 实现 call_ledger.py 的 CallRecord / CallLedger（JSONL 持久化）
+    status: pending
+  - id: t4
+    content: 实现 reconcile() 四态判决
+    status: pending
+  - id: t5
+    content: tests/test_reliability_call_identity.py + tests/test_reliability_ledger.py 全绿
+    status: pending
+isProject: false
+---
+
+# Subplan 01：Tool-call 规范身份与幂等账本
+
+**Plan-Id**: `2026-09-12-sdk-reliability-01-call-identity`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-01-call-identity.plan.md`
+**Master**: `2026-09-12-sdk-reliability-kernel-master`
+**Planned-with**: Claude Opus 5
+**Suggested-Impl-Model**: Grok 4.6
+**Made-with**: Damon Li
+
+---
+
+## 1. 要解决什么（根因与证据）
+
+**现状事实（已核对，不需回看对话）：**
+
+1. 全仓 `rg 'fingerprint' agenticx/` 的命中里，没有一个是工具调用身份：
+   - `agenticx/runtime/prompt_cache_policy.py` → LLM 前缀缓存指纹
+   - `agenticx/studio/kb/ingest_cache.py` → 知识库入库去重指纹
+   - `agenticx/runtime/loop_detector.py::fingerprint_from_result` → 循环检测的**结果**指纹（用于判断「有没有进展」，不是身份）
+2. `agenticx/runtime/interrupted_closers.py:18-22` 的 `OUTCOME_UNKNOWN_CONTENT` 是当前唯一的崩溃恢复手段，内容是一段自然语言，要求 LLM「先用只读方式核验外部状态」。**幂等判断被外包给模型的自觉性。**
+3. `agenticx/agents/react_agent_async.py` 里 tool_call id 的取法本身就不自洽：
+   - `:263` 发事件时用 `tc_id = str(tc.get("id", "") or f"call_{name}_{iterations}")`（有兜底）
+   - `:275` 真执行时用 `str(tc.get("id", "") or "")`（无兜底，可能是空串）
+   - `:288` 写回 tool 消息时又用 `str(tc.get("id", "") or "")`
+   
+   同一次调用在事件流里的 id 和在 messages 里的 id **可能不同**。这使得任何基于 id 的账本都不可靠，必须在 02 里统一（本 Subplan 只提供 `stable_call_id()` 工具函数，实际替换在 02 做）。
+
+**对标上游**：`openai/openai-agents-python@fbd2dbc` 用 `call_id + payload fingerprint` 作为调用身份，完全相同的调用可跳过重放，同 id 但参数变了直接抛 `ModelBehaviorError`。我们要在语义上对齐并且更严格（AMBIGUOUS 单独成态，fail-closed）。
+
+---
+
+## 2. In scope / Out of scope
+
+### In scope
+
+新增以下文件，**全部是新文件，不修改任何既有文件**：
+
+- `agenticx/reliability/__init__.py`
+- `agenticx/reliability/errors.py`
+- `agenticx/reliability/call_identity.py`
+- `agenticx/reliability/call_ledger.py`
+- `tests/test_reliability_call_identity.py`
+- `tests/test_reliability_ledger.py`
+
+### Out of scope
+
+- **不改** `agenticx/agents/react_agent_async.py`（接入在 Subplan 02）。
+- **不改** `agenticx/runtime/interrupted_closers.py`（保持纯函数与现有文案）。
+- **不改** `agenticx/runtime/checkpoint.py`。
+- **不做**分布式锁 / 跨主机 CAS。
+- **不引入任何新的第三方依赖**（只用标准库 `json` / `hashlib` / `pathlib` / `dataclasses` / `threading`）。
+- 不做 CLI 入口、不做 REST 路由。
+
+---
+
+## 3. 文件 1：`agenticx/reliability/errors.py`
+
+```python
+#!/usr/bin/env python3
+"""Reliability kernel exceptions.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+
+class ReliabilityError(Exception):
+    """Base class for reliability-kernel failures."""
+
+
+class ToolCallIdentityError(ReliabilityError):
+    """Same ``call_id`` reappeared with a different canonical payload.
+
+    This is never recoverable by retrying: the model either fabricated an id
+    or the transport corrupted the call. Fail loudly instead of guessing which
+    payload was intended.
+    """
+
+    def __init__(
+        self,
+        call_id: str,
+        *,
+        recorded_key: str,
+        incoming_key: str,
+        changed_fields: tuple[str, ...] = (),
+    ) -> None:
+        self.call_id = call_id
+        self.recorded_key = recorded_key
+        self.incoming_key = incoming_key
+        self.changed_fields = changed_fields
+        fields = ", ".join(changed_fields) if changed_fields else "<unknown>"
+        super().__init__(
+            f"tool call id {call_id!r} reused with different arguments: "
+            f"recorded key {recorded_key[:16]}, incoming key {incoming_key[:16]}, "
+            f"changed fields: {fields}"
+        )
+
+
+class LedgerCorruptError(ReliabilityError):
+    """Ledger file exists but cannot be parsed into a usable state."""
+```
+
+**注意 AC-M4 的要求**：异常消息必须含 `call_id`、两个 key 的前 16 位、变化的字段名。上面的实现已满足，不要简化。
+
+---
+
+## 4. 文件 2：`agenticx/reliability/call_identity.py`
+
+### 4.1 职责
+
+把 `(tool_name, arguments)` 规范化成一个稳定字符串键。**同一次逻辑调用在任何机器、任何 Python 版本、任何 dict 插入顺序下必须得到同一个键。**
+
+### 4.2 精确要求（逐条实现，不要"按需推断"）
+
+| 规则 | 要求 | 理由 |
+|---|---|---|
+| dict 键序 | `sort_keys=True` | 模型两次生成的 JSON 键序可能不同，但是同一次调用 |
+| 分隔符 | `separators=(",", ":")` | 消除空白差异 |
+| 非 ASCII | `ensure_ascii=False` | 中文参数不应因转义方式不同而变键 |
+| `float` | `repr(v)` 归一；`-0.0` 归一为 `0.0` | `1.0` 与 `1` 必须**不同**键（类型是语义的一部分），但 `-0.0`/`0.0` 相同 |
+| `NaN` / `Inf` | 抛 `ValueError` | 不可比较的值不能当身份 |
+| 嵌套结构 | 递归规范化 dict / list / tuple | tuple 归一为 list（JSON 无 tuple） |
+| set / frozenset | 排序后归一为 list；元素不可排序时按 `repr` 排序 | 保证确定性 |
+| 未知类型 | 抛 `TypeError`，消息含类型名与路径 | 静默 `str()` 会让不同对象撞键 |
+| 摘要 | `hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()` | 定长、可日志化 |
+| 键格式 | `f"{tool_name}:{sha256_hex}"` | 工具名进键，防止不同工具同参数撞键 |
+
+### 4.3 公开 API
+
+```python
+def canonical_payload(arguments: Any) -> str:
+    """Return the canonical JSON text for ``arguments``.
+
+    Raises ValueError on NaN/Inf, TypeError on unsupported types.
+    """
+
+
+def canonical_call_key(tool_name: str, arguments: Any) -> str:
+    """Return ``"<tool_name>:<sha256-of-canonical-payload>"``."""
+
+
+def diff_canonical_fields(a: Any, b: Any) -> tuple[str, ...]:
+    """Top-level + dotted nested field names whose canonical form differs.
+
+    Used only to make ToolCallIdentityError messages actionable. Best effort:
+    if either side is not a mapping, returns ``("<root>",)``.
+    """
+
+
+def stable_call_id(
+    raw_id: Any,
+    *,
+    tool_name: str,
+    iteration: int,
+    position: int,
+) -> str:
+    """Normalize a provider tool_call id into a non-empty stable id.
+
+    Some providers emit empty or missing ids. Falls back to a deterministic
+    synthetic id so ledger lookups never key on the empty string. The fallback
+    is deterministic across a resume of the same run, which is why it uses
+    (tool_name, iteration, position) rather than uuid4.
+
+    Fallback format: ``"synth-{tool_name}-{iteration}-{position}"``.
+    """
+```
+
+### 4.4 实现要点（伪代码）
+
+```python
+def _norm(value, path):
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ValueError(f"non-finite float at {path}")
+        return 0.0 if value == 0.0 else value
+    if isinstance(value, dict):
+        return {str(k): _norm(v, f"{path}.{k}") for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_norm(v, f"{path}[{i}]") for i, v in enumerate(value)]
+    if isinstance(value, (set, frozenset)):
+        items = [_norm(v, f"{path}{{}}") for v in value]
+        try:
+            return sorted(items)
+        except TypeError:
+            return sorted(items, key=repr)
+    raise TypeError(f"unsupported type {type(value).__name__} at {path}")
+```
+
+`bool` 必须在 `int` 之前判定（Python 中 `isinstance(True, int)` 为真）。
+
+---
+
+## 5. 文件 3：`agenticx/reliability/call_ledger.py`
+
+### 5.1 数据模型
+
+```python
+CallState = Literal["dispatched", "completed", "failed"]
+
+
+@dataclass
+class CallRecord:
+    call_id: str
+    canonical_key: str
+    tool_name: str
+    state: CallState
+    dispatched_at: float
+    completed_at: float | None = None
+    result_digest: str | None = None      # sha256 of result text, for audit
+    result_payload: str | None = None     # stored result, enables REPLAY_SKIP
+    error: str | None = None
+    replay_safety: str = "unknown"        # consumed by Subplan 03
+```
+
+`result_payload` 是 `REPLAY_SKIP` 能返回真实结果的前提。为避免账本无限膨胀，超过 `max_inline_result_bytes`（默认 `65536`）时只存 `result_digest`，`result_payload=None`，此时 `reconcile` 对该记录返回 `AMBIGUOUS` 而不是 `REPLAY_SKIP`（**宁可多问一次，不要凭摘要伪造结果**）。
+
+### 5.2 判决枚举
+
+```python
+class Verdict(str, Enum):
+    FRESH = "fresh"                        # 从未见过，正常执行
+    REPLAY_SKIP = "replay_skip"            # 同 id 同 key 且已完成且结果可复用 → 直接返回存档结果
+    AMBIGUOUS = "ambiguous"                # 同 id 同 key 但状态为 dispatched（或结果未内联）→ 外部状态未知
+    IDENTITY_CONFLICT = "identity_conflict"  # 同 id 不同 key → 抛 ToolCallIdentityError
+```
+
+```python
+@dataclass
+class Reconciliation:
+    verdict: Verdict
+    record: CallRecord | None = None
+    replay_result: str | None = None   # 仅 REPLAY_SKIP 时非 None
+```
+
+### 5.3 `CallLedger` 接口
+
+```python
+class CallLedger:
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        root: str | Path | None = None,
+        max_inline_result_bytes: int = 65536,
+    ) -> None:
+        """Per-session append-only ledger.
+
+        Default root is ``~/.agenticx/sessions/<session_id>/`` resolved via
+        ``agenticx.utils.agx_home.agx_home()``; the ledger file is
+        ``call_ledger.jsonl``. ``root`` overrides the parent directory (tests
+        pass tmp_path).
+        """
+
+    # --- write path -------------------------------------------------
+    def record_dispatch(self, call_id: str, tool_name: str, arguments: Any,
+                        *, replay_safety: str = "unknown") -> CallRecord: ...
+    def record_result(self, call_id: str, result: str, *, success: bool = True) -> None: ...
+    def record_failure(self, call_id: str, error: str) -> None: ...
+
+    # --- read path --------------------------------------------------
+    def lookup(self, call_id: str) -> CallRecord | None: ...
+    def reconcile(self, call_id: str, tool_name: str, arguments: Any) -> Reconciliation: ...
+    def pending_call_ids(self) -> tuple[str, ...]:
+        """call_ids whose state is still 'dispatched' (crash-window set)."""
+
+    # --- lifecycle --------------------------------------------------
+    @classmethod
+    def load(cls, session_id: str, *, root=None) -> "CallLedger":
+        """Rebuild in-memory index by replaying the JSONL file."""
+    def close(self) -> None: ...
+```
+
+### 5.4 持久化契约（照做，不要发挥）
+
+- 文件：`<root>/<session_id>/call_ledger.jsonl`，**append-only**，一行一个 JSON 对象。
+- 每行结构：`{"v": 1, "op": "dispatch"|"result"|"failure", "ts": <float>, ...CallRecord 字段子集}`。
+  - `"v"` 是 schema 版本，读取时遇到 `v > 1` 记 warning 并跳过该行（向前兼容）。
+- **写入必须在返回前 flush + fsync**：
+  ```python
+  self._fh.write(line + "\n")
+  self._fh.flush()
+  os.fsync(self._fh.fileno())
+  ```
+  不 fsync 就等于没写——本模块的全部价值是「崩溃后账本还在」。这是 fail-closed 姿态，不要为了性能去掉。
+- 写失败必须**抛出**，不得像 `agenticx/runtime/checkpoint.py:73-88` 那样 `logger.warning` 后吞掉。账本写不进去 = 幂等保证失效 = 必须让调用方知道。
+- 单行解析失败：记 warning 跳过；如果**整个文件**一行都解析不出且文件非空，抛 `LedgerCorruptError`。
+- 目录不存在时 `mkdir(parents=True, exist_ok=True)`。
+- `session_id` 做路径穿越防护：拒绝含 `/`、`\`、`..` 的值（参照 `agenticx/core/offload/file_offloader.py` 已有的防护写法）。
+- 线程安全：用一把 `threading.Lock` 保护写路径与内存索引。不需要跨进程锁（per-session 单写者；如需多进程，调用方自行用已有的 `agenticx.sessions.SessionWriteLock`，本模块不重复实现）。
+
+### 5.5 `reconcile()` 判决逻辑（精确顺序）
+
+```
+key = canonical_call_key(tool_name, arguments)
+rec = lookup(call_id)
+
+1. rec is None                          -> FRESH
+2. rec.canonical_key != key             -> raise ToolCallIdentityError(
+                                              call_id,
+                                              recorded_key=rec.canonical_key,
+                                              incoming_key=key,
+                                              changed_fields=diff_canonical_fields(...))
+                                           （调用方若捕获，视为 IDENTITY_CONFLICT）
+3. rec.state == "completed" and rec.result_payload is not None
+                                        -> REPLAY_SKIP (replay_result=rec.result_payload)
+4. rec.state == "failed"                -> FRESH   # 失败可以重试
+5. otherwise (dispatched，或 completed 但结果未内联)
+                                        -> AMBIGUOUS
+```
+
+第 2 步**抛异常**而不是返回 `IDENTITY_CONFLICT`，因为这是编程/协议错误而非可选路径。`Verdict.IDENTITY_CONFLICT` 枚举值保留给需要「不抛异常地分类」的调用方（Subplan 04 的基准会用到），并提供 `reconcile_safe()` 变体返回该枚举而不抛：
+
+```python
+def reconcile_safe(self, call_id, tool_name, arguments) -> Reconciliation:
+    """Like reconcile() but returns IDENTITY_CONFLICT instead of raising."""
+```
+
+### 5.6 `__init__.py` 导出
+
+```python
+from agenticx.reliability.call_identity import (
+    canonical_call_key, canonical_payload, diff_canonical_fields, stable_call_id,
+)
+from agenticx.reliability.call_ledger import (
+    CallLedger, CallRecord, CallState, Reconciliation, Verdict,
+)
+from agenticx.reliability.errors import (
+    LedgerCorruptError, ReliabilityError, ToolCallIdentityError,
+)
+
+__all__ = [...]  # 列全上面所有名字
+```
+
+**`agenticx/reliability/__init__.py` 严禁 import `agenticx.studio` / `agenticx.cli` 下的任何东西**，否则会破坏 SDK 侧的零产品耦合（见 master plan 的 AC-M5）。
+
+---
+
+## 6. 验收标准（AC）
+
+### AC-1：规范化键的稳定性
+
+`tests/test_reliability_call_identity.py` 必须包含：
+
+| 测试名 | 断言 |
+|---|---|
+| `test_key_stable_across_dict_order` | `canonical_call_key("t", {"a":1,"b":2}) == canonical_call_key("t", {"b":2,"a":1})` |
+| `test_key_differs_by_tool_name` | 同参数、不同 tool_name → 键不同 |
+| `test_int_and_float_differ` | `{"n": 1}` 与 `{"n": 1.0}` → 键**不同** |
+| `test_negative_zero_normalized` | `{"n": -0.0}` 与 `{"n": 0.0}` → 键**相同** |
+| `test_nan_rejected` | `canonical_payload({"n": float("nan")})` 抛 `ValueError` |
+| `test_inf_rejected` | `float("inf")` 抛 `ValueError` |
+| `test_unsupported_type_rejected` | 传入 `object()` 抛 `TypeError`，消息含 `"object"` |
+| `test_bool_not_int` | `{"f": True}` 与 `{"f": 1}` → 键**不同** |
+| `test_nested_normalized` | `{"a": {"x": [1, {"z": 2}]}}` 两种键序写法 → 键相同 |
+| `test_tuple_equals_list` | `{"a": (1, 2)}` 与 `{"a": [1, 2]}` → 键**相同** |
+| `test_unicode_stable` | `{"名": "值"}` 可算键且不含转义序列（断言 `"名" in canonical_payload(...)`） |
+| `test_stable_call_id_fallback_deterministic` | 同 `(tool_name, iteration, position)` 两次调用 → 同 id；`raw_id` 非空时原样返回 |
+| `test_diff_fields_reports_changed_key` | `diff_canonical_fields({"a":1,"b":2}, {"a":1,"b":3}) == ("b",)` |
+
+### AC-2：账本行为
+
+`tests/test_reliability_ledger.py`（全部用 `tmp_path` 作 `root`）：
+
+| 测试名 | 断言 |
+|---|---|
+| `test_fresh_when_unseen` | `reconcile` → `Verdict.FRESH` |
+| `test_replay_skip_returns_stored_result` | dispatch → result("OK") → `reconcile` 返回 `REPLAY_SKIP` 且 `replay_result == "OK"` |
+| `test_ambiguous_when_dispatched_only` | dispatch 后不 record_result → `AMBIGUOUS` |
+| `test_failed_becomes_fresh` | `record_failure` 后 → `FRESH` |
+| `test_identity_conflict_raises` | 同 call_id 不同参数 → 抛 `ToolCallIdentityError`；异常 `str()` 含 call_id 且含 `"b"`（变化字段） |
+| `test_reconcile_safe_does_not_raise` | 同上场景走 `reconcile_safe` → `Verdict.IDENTITY_CONFLICT` |
+| `test_large_result_not_inlined` | `max_inline_result_bytes=8`，写入 `"x"*100` → `reconcile` 得 `AMBIGUOUS`，且 `record.result_digest` 非空、`result_payload is None` |
+| `test_survives_reload` | 写 3 条后 `CallLedger.load(...)` 重建，`lookup` 全部命中、`reconcile` 判决与重启前一致 |
+| `test_pending_call_ids` | 2 个 dispatched + 1 个 completed → `pending_call_ids()` 只含前两个 |
+| `test_write_failure_raises` | 用 `monkeypatch` 让 `os.fsync` 抛 `OSError` → `record_dispatch` **抛出**（不得静默） |
+| `test_corrupt_file_raises` | 预置一个全是 `"not json"` 的非空文件 → `CallLedger.load` 抛 `LedgerCorruptError` |
+| `test_partial_corrupt_line_skipped` | 3 行中第 2 行坏 → `load` 成功，另外 2 条可用 |
+| `test_unknown_schema_version_skipped` | 预置 `{"v": 99, ...}` 行 → 跳过且不抛 |
+| `test_path_traversal_rejected` | `CallLedger("../evil", root=tmp_path)` 抛 `ValueError` |
+| `test_jsonl_is_append_only` | 记录 3 次后文件行数 == 3；再 record_result 一次 → 4 行（不是原地改写） |
+
+### AC-3：零耦合与整体门槛
+
+```bash
+# 1) 测试全绿
+pytest tests/test_reliability_call_identity.py tests/test_reliability_ledger.py -q
+
+# 2) 不引入 studio 依赖
+python -c "import sys, agenticx.reliability; assert not [m for m in sys.modules if m.startswith('agenticx.studio')], sorted(m for m in sys.modules if m.startswith('agenticx.studio'))"
+
+# 3) 不引入新第三方依赖：确认 git diff 未触碰 pyproject.toml / requirements.txt
+git diff --name-only | grep -E 'pyproject.toml|requirements.txt' && echo "FAIL: dependency changed" || echo "OK"
+```
+
+---
+
+## 7. no-scope-creep 边界
+
+实施本 Subplan 时，`git status` 里**只应出现**第 2 节 In scope 列出的 6 个新文件。如果出现任何既有文件的修改，说明越界了，回退。
+
+特别地：看到 `react_agent_async.py` 的 `tc_id` 不一致（第 1 节第 3 点）**不要顺手修**——那是 Subplan 02 的 t1，在这里改会让 02 的验收失去基线。

--- a/.cursor/plans/2026-09-12-sdk-reliability-02-sdk-durability.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-02-sdk-durability.plan.md
@@ -1,0 +1,554 @@
+---
+name: sdk-reliability-02-sdk-durability
+overview: 给可嵌入的 SDK 原语 ReActAgent 补上崩溃续跑能力。当前 agenticx/agents/react_agent_async.py（402 行）的 astream() 是纯内存循环，messages 是局部变量，进程一死全丢；CancelledError 分支只 yield ErrorEvent 就 raise，连已完成的工具结果一起丢弃。而唯一的 CheckpointStore 在 agenticx/runtime/checkpoint.py 里 import agenticx.studio.storage，无法复用（会破坏 SDK 零 Studio 耦合契约）。本 Subplan 新建 agenticx/reliability/run_state.py 提供与 Studio 解耦的可序列化 RunState + 文件后端 RunStateStore，接入 ReActAgent 的 astream/arun 并新增 aresume()，同时修掉 tool_call id 在事件流与 messages 之间不自洽的既有缺陷（账本依赖稳定 id）。
+todos:
+  - id: t1
+    content: 统一 ReActAgent 的 tool_call id 取法（stable_call_id 单一收口）
+    status: pending
+  - id: t2
+    content: 新建 agenticx/reliability/run_state.py（RunState + RunStateStore）
+    status: pending
+  - id: t3
+    content: ReActAgent 接入 run_store / ledger，在两个边界写检查点
+    status: pending
+  - id: t4
+    content: 取消/中断时落盘部分状态并产出 InterruptedEvent
+    status: pending
+  - id: t5
+    content: 实现 ReActAgent.aresume()（账本驱动的跳过与追问）
+    status: pending
+  - id: t6
+    content: tests/test_reliability_run_state.py + tests/test_react_agent_resume.py 全绿
+    status: pending
+isProject: false
+---
+
+# Subplan 02：SDK 侧 RunState 持久化与续跑
+
+**Plan-Id**: `2026-09-12-sdk-reliability-02-sdk-durability`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-02-sdk-durability.plan.md`
+**Master**: `2026-09-12-sdk-reliability-kernel-master`
+**依赖**: Subplan 01 必须先完成（本 plan 使用 `CallLedger` / `canonical_call_key` / `stable_call_id`）
+**Planned-with**: Claude Opus 5
+**Suggested-Impl-Model**: Grok 4.6
+**Made-with**: Damon Li
+
+---
+
+## 1. 要解决什么（根因与证据）
+
+### 1.1 SDK 原语完全没有持久化
+
+`agenticx/agents/react_agent_async.py` 全文 402 行，`rg 'checkpoint|persist|resume'` **零命中**。
+
+具体看 `astream()`（`:220-341`）：
+
+```220:232:agenticx/agents/react_agent_async.py
+    async def astream(
+        self,
+        query: str,
+        *,
+        history: Optional[List[Dict[str, Any]]] = None,
+    ) -> AsyncIterator[AgentEvent]:
+        """Run the FC loop, yielding typed events (NFR-4 source of truth)."""
+        self._stop_requested = False
+        messages = self._build_messages(query, history)
+        iterations = 0
+
+        try:
+            while iterations < self.max_iterations:
+```
+
+`messages` 是局部变量。进程崩溃后：已跑完的工具、已产生的副作用、已累积的对话历史，**全部无从得知**。
+
+取消路径更糟：
+
+```339:341:agenticx/agents/react_agent_async.py
+        except asyncio.CancelledError:
+            yield ErrorEvent(message="cancelled", recoverable=False)
+            raise
+```
+
+`messages` 没有随事件流出，调用方拿不到任何可续跑的东西。对比 `agenticx/runtime/agent_runtime.py` 的 `_finalize_cancelled_prefix()`（受 `AGX_CANCELLED_PREFIX_FINALIZE` 控制，默认开）——Studio 侧考虑过这个问题，SDK 侧没有。
+
+### 1.2 既有 CheckpointStore 不可复用
+
+`agenticx/runtime/checkpoint.py:32-33`：
+
+```python
+from agenticx.studio.storage.backend import SyncStorageFacade
+from agenticx.studio.storage.factory import get_sync_storage
+```
+
+`agenticx.agents` 若 import 它，就会反向依赖 `agenticx.studio`，破坏 `conclusions/agents_module_conclusion.md` 记录的既有契约（「不依赖 `AgentExecutor` 或任何 Studio/CLI 运行时」，且已有冒烟测试断言这一点）。所以必须在 `agenticx/reliability/` 里新写一个与 Studio 无关的存储。
+
+另外 `CheckpointStore.save()` 的失败语义也不能照抄：
+
+```73:88:agenticx/runtime/checkpoint.py
+    def save(self, checkpoint: AgentCheckpoint) -> None:
+        try:
+            ...
+        except Exception:
+            logger.warning(
+                "checkpoint save failed session=%s",
+                checkpoint.session_id,
+                exc_info=True,
+            )
+```
+
+写失败被吞掉 → 运行照常继续 → 崩溃后无从恢复 → 没人知道。本 Subplan 的 `RunStateStore` 必须**抛出**。
+
+### 1.3 tool_call id 在同一次调用里不自洽（必须先修）
+
+同一个 `tc`，三处取 id 的方式不同：
+
+```262:263:agenticx/agents/react_agent_async.py
+                    args = _parse_tool_arguments(fn.get("arguments"))
+                    tc_id = str(tc.get("id", "") or f"call_{name}_{iterations}")
+```
+
+```271:283:agenticx/agents/react_agent_async.py
+                results = await asyncio.gather(
+                    *[
+                        self._execute_one_tool(
+                            str(tc.get("id", "") or ""),
+                            str((tc.get("function") or {}).get("name", "") or ""),
+                            _parse_tool_arguments(
+                                (tc.get("function") or {}).get("arguments"),
+                            ),
+                        )
+                        for tc in pending
+                    ],
+                    return_exceptions=True,
+                )
+```
+
+```287:288:agenticx/agents/react_agent_async.py
+                    fn = tc.get("function") or {}
+                    name = str(fn.get("name", "") or "")
+                    tc_id = str(tc.get("id", "") or "")
+```
+
+`:263` 有 `f"call_{name}_{iterations}"` 兜底，`:275` 和 `:288` 没有。当 provider 不给 id（部分兼容代理会这样）时，事件流里的 id 是 `call_echo_1`，messages 里的是 `""`，账本会把不同调用全部记到空串键上。
+
+**这不是 scope creep，是本 Subplan 的前置修复**：账本依赖稳定 id，id 不稳定则 Subplan 01 的全部保证失效。修法是引入单一收口（见第 4 节 t1）。
+
+---
+
+## 2. In scope / Out of scope
+
+### In scope
+
+**新增：**
+- `agenticx/reliability/run_state.py`
+- `tests/test_reliability_run_state.py`
+- `tests/test_react_agent_resume.py`
+
+**修改（仅这两个文件）：**
+- `agenticx/agents/react_agent_async.py`
+- `agenticx/agents/agent_events.py`（新增 1 个事件类型 `InterruptedEvent`，加入 `AgentEvent` 联合）
+- `agenticx/reliability/__init__.py`（追加导出）
+
+### Out of scope
+
+- **不改** `agenticx/runtime/agent_runtime.py`（产品侧接入不在第一阶段）。
+- **不改** `agenticx/runtime/checkpoint.py`（Studio 的 checkpoint 保持原样；两套并存是有意的）。
+- **不改** `agenticx/runtime/interrupted_closers.py`。
+- **不改** `agenticx/agents/react_agent.py`（legacy `TextReActAgent` 门面不动）。
+- **不改** `agenticx/studio/**` 任何文件。
+- 不做重放安全否决（Subplan 03）；本 plan 里所有 `AMBIGUOUS` 一律走「暴露给调用方 + 默认不重跑」的保守路径。
+- 不做故障注入测试框架（Subplan 04）；本 plan 的测试用直接调用 `aresume()` 模拟崩溃。
+- 不新增第三方依赖。
+- `ReActAgent` 的既有构造参数与 `arun`/`astream`/`run` 签名**保持向后兼容**：所有新参数必须是 keyword-only 且有默认值，默认值下行为与现在**逐字节一致**（无 run_store 时不落盘、不产生新事件）。
+
+---
+
+## 3. 文件：`agenticx/reliability/run_state.py`
+
+### 3.1 数据模型
+
+```python
+RUN_STATE_SCHEMA_VERSION = 1
+
+
+@dataclass
+class PendingCall:
+    call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    canonical_key: str
+
+
+@dataclass
+class RunState:
+    """Serializable snapshot of an in-flight ReActAgent run.
+
+    Unlike ``agenticx.runtime.checkpoint.AgentCheckpoint`` this type has no
+    Studio dependency and carries the full message list, so an embedder can
+    resume without a session backend.
+    """
+
+    run_id: str
+    session_id: str
+    schema_version: int = RUN_STATE_SCHEMA_VERSION
+    query: str = ""
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    iteration: int = 0
+    phase: Literal["before_llm", "tools_dispatched", "completed", "interrupted"] = "before_llm"
+    pending_calls: list[PendingCall] = field(default_factory=list)
+    created_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]: ...
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "RunState": ...
+```
+
+`phase` 的语义（**这是恢复决策的唯一依据，不要引入第五个值**）：
+
+| phase | 含义 | 恢复动作 |
+|---|---|---|
+| `before_llm` | 本轮 LLM 请求还没发出 | 直接从 `iteration` 继续，重发 LLM 请求（LLM 请求本身无外部副作用） |
+| `tools_dispatched` | 工具已派发，结果未必回来 | 对每个 `pending_calls` 查账本判决（见第 5 节） |
+| `completed` | 已产出 FinalEvent | 无需恢复；`aresume` 直接返回终态 |
+| `interrupted` | 用户取消或 stop() | 保留 messages 供调用方决定是否续问 |
+
+### 3.2 `RunStateStore`
+
+```python
+class RunStateStore:
+    """File-backed RunState persistence (atomic replace, fail-closed)."""
+
+    def __init__(self, session_id: str, *, root: str | Path | None = None) -> None:
+        """Default root: ``~/.agenticx/sessions/<session_id>/`` via
+        ``agenticx.utils.agx_home.agx_home()``. State file: ``run_state.json``.
+        Rejects session_id containing '/', '\\' or '..' (same guard as
+        CallLedger in Subplan 01)."""
+
+    def save(self, state: RunState) -> None:
+        """Atomically persist. RAISES on failure — never swallow.
+
+        Uses ``agenticx.utils.atomic_writer.atomic_write_json`` so a crash
+        mid-write cannot leave a truncated file.
+        """
+
+    def load(self) -> RunState | None:
+        """Return None when absent. Raises ValueError when schema_version >
+        RUN_STATE_SCHEMA_VERSION (refuse to guess a future format)."""
+
+    def clear(self) -> None:
+        """Delete the state file; missing file is not an error."""
+```
+
+**必须用** `agenticx.utils.atomic_writer.atomic_write_json`（该函数已存在于 `agenticx/utils/atomic_writer.py:32`）。不要自己写 `open(...).write()`——崩溃时会留下半截 JSON，恢复直接失败。
+
+对比：`RunStateStore.save` 抛异常，`agenticx/runtime/checkpoint.py:73-88` 吞异常。这是刻意的差异，代码里加一行注释说明。
+
+### 3.3 `__init__.py` 追加导出
+
+```python
+from agenticx.reliability.run_state import (
+    RUN_STATE_SCHEMA_VERSION, PendingCall, RunState, RunStateStore,
+)
+```
+
+---
+
+## 4. 改造 `agenticx/agents/react_agent_async.py`
+
+### t1：tool_call id 单一收口（先做，独立可验证）
+
+新增一个私有辅助方法，把「从 provider 的 tc dict 里解析出规范三元组」收敛到一处：
+
+```python
+    def _normalize_tool_call(
+        self,
+        tc: Dict[str, Any],
+        *,
+        iteration: int,
+        position: int,
+    ) -> tuple[str, str, Dict[str, Any]]:
+        """Return (stable_call_id, tool_name, arguments) for one provider tool_call.
+
+        Single chokepoint: every id used in events, execution and the tool
+        message row comes from here, so a ledger keyed on call_id stays valid
+        even when the provider omits ids.
+        """
+        fn = tc.get("function") or {}
+        name = str(fn.get("name", "") or "")
+        args = _parse_tool_arguments(fn.get("arguments"))
+        call_id = stable_call_id(
+            tc.get("id"),
+            tool_name=name,
+            iteration=iteration,
+            position=position,
+        )
+        return call_id, name, args
+```
+
+然后**把 `:259-319` 的三处解析全部替换为一次解析、结果复用**。改造后的结构（before → after 意图）：
+
+**before**（现在的样子，三次独立解析）：
+```
+for tc in tool_calls:            # 解析第 1 次，id 有兜底
+    ...yield ToolCallEvent(tc_id, ...)
+results = await gather(          # 解析第 2 次，id 无兜底
+    self._execute_one_tool(str(tc.get("id","") or ""), ...) for tc in pending
+)
+for tc, result in zip(...):      # 解析第 3 次，id 无兜底
+    ...messages.append({"tool_call_id": tc_id, ...})
+```
+
+**after**（一次解析，三处复用）：
+```
+normalized = [
+    self._normalize_tool_call(tc, iteration=iterations, position=i)
+    for i, tc in enumerate(tool_calls)
+]
+for call_id, name, args in normalized:
+    yield ToolCallEvent(tool_call_id=call_id, tool_name=name, arguments=args)
+
+results = await asyncio.gather(
+    *[self._execute_one_tool(call_id, name, args) for call_id, name, args in normalized],
+    return_exceptions=True,
+)
+
+for (call_id, name, args), result in zip(normalized, results):
+    ...
+    messages.append({"role": "tool", "tool_call_id": call_id, "content": content})
+    yield ToolResultEvent(tool_call_id=call_id, tool_name=name, content=content, success=success)
+```
+
+`pending` 这个中间列表随之删除（它只是 `tool_calls` 的副本，见 `:258` 与 `:264`）。
+
+**注意**：`self.loop_detector.record_call(...)`（`:296-305`）的参数改为复用 `args`，不要再调 `_parse_tool_arguments(fn.get("arguments"))` 第四次。
+
+### t3：构造参数与检查点写入
+
+`__init__` 新增 keyword-only 参数（**加在现有参数之后，不改任何既有参数的顺序或默认值**）：
+
+```python
+        run_store: "RunStateStore | None" = None,
+        call_ledger: "CallLedger | None" = None,
+        run_id: str | None = None,
+```
+
+- 两者都为 `None`（默认）→ 行为与现在完全一致，零新增 IO、零新增事件。
+- `run_store` 非 None → 在两个边界落盘。
+- `call_ledger` 非 None → 记录 dispatch/result，并在 `aresume` 时用于判决。
+- 允许只给 `run_store` 不给 `call_ledger`（此时恢复只能靠 `phase`，`tools_dispatched` 一律按 AMBIGUOUS 处理）；反之亦可。
+
+**落盘点只有两个**，不要多加：
+
+1. **发 LLM 请求之前**（现 `:243-244` 之间）：
+   ```python
+   messages = await self._maybe_compact(messages)
+   self._save_state(phase="before_llm", messages=messages, iteration=iterations)
+   response = await self._ainvoke(messages)
+   ```
+2. **工具派发之前**（yield 完 `ToolCallEvent`、gather 之前）：
+   ```python
+   self._save_state(
+       phase="tools_dispatched",
+       messages=messages,
+       iteration=iterations,
+       pending_calls=[PendingCall(call_id, name, args, canonical_call_key(name, args))
+                      for call_id, name, args in normalized],
+   )
+   if self._ledger is not None:
+       for call_id, name, args in normalized:
+           self._ledger.record_dispatch(call_id, name, args)
+   ```
+
+工具结果回来后（每个 `zip` 迭代内）：
+```python
+   if self._ledger is not None:
+       if success:
+           self._ledger.record_result(call_id, content)
+       else:
+           self._ledger.record_failure(call_id, content)
+```
+
+产出 `FinalEvent` 之前：`self._save_state(phase="completed", ...)`；`FinalEvent` yield 之后调用 `self._run_store.clear()`（终态不留残留状态，否则下次 `aresume` 会误判有未完成的 run）。
+
+`_save_state` 的实现：
+```python
+    def _save_state(self, *, phase, messages, iteration, pending_calls=()) -> None:
+        if self._run_store is None:
+            return
+        state = RunState(
+            run_id=self._run_id,
+            session_id=self.session_id,
+            query=self._current_query,
+            messages=list(messages),
+            iteration=iteration,
+            phase=phase,
+            pending_calls=list(pending_calls),
+        )
+        self._run_store.save(state)   # 故意不 try/except：写不进去就该炸
+```
+
+### t4：取消 / 中断落盘
+
+改造 `:232-238` 的 stop 分支与 `:339-341` 的 `CancelledError` 分支：两处都先落盘 `phase="interrupted"`，再产出新的 `InterruptedEvent`（带 messages），`CancelledError` 分支仍然 `raise`。
+
+`agenticx/agents/agent_events.py` 新增：
+
+```python
+@dataclass
+class InterruptedEvent:
+    """Run stopped before producing a final output; carries resumable state."""
+    reason: Literal["user_stop", "cancelled"]
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    iteration: int = 0
+    run_id: str = ""
+```
+
+并把它加入 `AgentEvent = Union[...]`。
+
+> 事件类型上限：`conclusions/agents_module_conclusion.md` 记录「最小化（≤6 类）」。加上 `InterruptedEvent` 是 7 类。这是有意的扩张——「被中断且可续跑」是与 `ErrorEvent`（错误）语义不同的一等状态，不能复用 `ErrorEvent(recoverable=False)` 表达。实施时同步把该 conclusion 的「≤6 类」表述更新为 7 类（这是 conclusion 维护，不是 scope creep）。
+
+`arun()` 里相应处理：遇到 `InterruptedEvent` 时把 `messages` 填进 `ReActResult.messages`，`success=False`，`error` 设为 `f"interrupted: {reason}"`。**不要**改 `ReActResult` 的字段。
+
+### t5：`aresume()`
+
+```python
+    async def aresume(
+        self,
+        state: "RunState | None" = None,
+    ) -> AsyncIterator[AgentEvent]:
+        """Resume an interrupted run from persisted state.
+
+        When ``state`` is None, loads from ``run_store``. Raises RuntimeError
+        when neither is available.
+        """
+```
+
+恢复流程（按 `phase` 分派，严格照做）：
+
+```
+state.phase == "completed"
+    -> yield FinalEvent(output=<last assistant content>, success=True,
+                        messages=state.messages, iterations=state.iteration)
+       return
+
+state.phase in ("before_llm", "interrupted")
+    -> messages = state.messages
+       iterations = state.iteration
+       进入与 astream 相同的主循环（从 iterations 继续，不 +1）
+       # LLM 请求可安全重放：它本身不产生外部副作用
+
+state.phase == "tools_dispatched"
+    -> 对 state.pending_calls 逐个判决：
+       a) 没有 ledger            -> 全部按 AMBIGUOUS 处理
+       b) ledger.reconcile_safe(call_id, tool_name, arguments):
+          REPLAY_SKIP        -> 用 replay_result 直接补 tool 消息行 + yield ToolResultEvent
+          FRESH              -> 重新执行该工具（账本证明它没跑过）
+          AMBIGUOUS          -> 补一条 tool 消息行，content 取
+                                agenticx.runtime.interrupted_closers.OUTCOME_UNKNOWN_CONTENT，
+                                metadata.kind 取 KIND_OUTCOME_UNKNOWN；
+                                并 yield ToolResultEvent(success=False)
+          IDENTITY_CONFLICT  -> 抛 ToolCallIdentityError（不可恢复）
+       补齐所有 pending 的 tool 行后，从 iterations + 1 继续主循环
+```
+
+**关于复用 `interrupted_closers` 的常量**：只 `from agenticx.runtime.interrupted_closers import OUTCOME_UNKNOWN_CONTENT, KIND_OUTCOME_UNKNOWN` 引用两个常量，**不调用** `close_interrupted_tool_calls()`（那是给 Studio 的整表扫描用的，这里我们已经精确知道哪些 pending）。`agenticx.runtime.interrupted_closers` 是纯函数模块、零 Studio 依赖，import 它不破坏 AC-M5。
+
+为避免 `astream` 与 `aresume` 的主循环重复实现，把主循环抽成一个私有 async generator：
+
+```python
+    async def _loop(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        start_iteration: int,
+    ) -> AsyncIterator[AgentEvent]:
+        """Shared FC loop body used by astream() and aresume()."""
+```
+
+`astream()` 变成「建 messages → 委托 `_loop(messages, start_iteration=0)`」，`aresume()` 变成「恢复 messages/补齐 pending → 委托 `_loop(messages, start_iteration=state.iteration)`」。这是**必要重构**，因为两份拷贝一定会漂移。
+
+---
+
+## 5. 验收标准（AC）
+
+### AC-1：向后兼容（最高优先，先跑）
+
+```bash
+# 既有 ReActAgent 测试必须零修改通过
+pytest tests/ -k "react_agent" -q
+# SDK 零 Studio 耦合仍然成立
+python -c "import sys, agenticx.agents; assert not [m for m in sys.modules if m.startswith('agenticx.studio')], sorted(m for m in sys.modules if m.startswith('agenticx.studio'))"
+```
+
+如果既有测试需要改才能过，说明破坏了兼容性 —— 回退重做，不要改测试。
+
+### AC-2：`tests/test_reliability_run_state.py`
+
+| 测试名 | 断言 |
+|---|---|
+| `test_roundtrip` | `RunState.from_dict(s.to_dict())` 与 `s` 等价（含 `pending_calls`） |
+| `test_save_load_clear` | save → load 得到等价对象；clear 后 load 返回 `None` |
+| `test_load_missing_returns_none` | 空目录 load → `None` |
+| `test_future_schema_rejected` | 预置 `{"schema_version": 999}` → load 抛 `ValueError` |
+| `test_save_failure_raises` | monkeypatch `atomic_write_json` 抛 `OSError` → `save` **抛出** |
+| `test_atomic_no_partial_file` | monkeypatch 让写入中途抛异常后，原有文件内容保持上一次成功的版本（不是半截 JSON） |
+| `test_path_traversal_rejected` | `RunStateStore("../evil", root=tmp_path)` 抛 `ValueError` |
+
+### AC-3：`tests/test_react_agent_resume.py`
+
+用一个 **确定性副作用计数器工具** 作为 oracle（测试内定义，不要引第三方）：
+
+```python
+class CounterTool(BaseTool):
+    """Increments a shared counter; the count IS the side effect under test."""
+    name = "bump"
+    # _run(self, *, key: str) -> str:  self.calls.append(key); return f"count={len(self.calls)}"
+```
+
+| 测试名 | 场景 | 断言 |
+|---|---|---|
+| `test_no_store_behaves_identically` | 不传 `run_store` / `call_ledger` | 事件序列与改造前一致；`tmp_path` 下无任何文件产生 |
+| `test_state_written_before_llm` | FakeLLM 在首次 `ainvoke` 抛异常 | `run_state.json` 存在且 `phase == "before_llm"` |
+| `test_state_written_before_tools` | FakeLLM 返回 1 个 tool_call，工具执行时抛 `KeyboardInterrupt` | 状态 `phase == "tools_dispatched"` 且 `pending_calls` 长度 1、`canonical_key` 非空 |
+| `test_resume_skips_completed_tool` | 手工构造 `phase="tools_dispatched"` + 账本里该 call 已 `completed(result="count=1")` | `aresume` 后 `CounterTool.calls` **长度不变**（未重复执行），且 messages 里出现 `content == "count=1"` 的 tool 行 |
+| `test_resume_reruns_fresh_tool` | 账本里没有该 call（证明未派发成功） | `aresume` 后计数器 +1 |
+| `test_resume_marks_ambiguous` | 账本里该 call 状态为 `dispatched`（无结果） | 计数器**不变**；messages 出现含 `OUTCOME_UNKNOWN_CONTENT` 的 tool 行，且该行 `metadata["kind"] == KIND_OUTCOME_UNKNOWN` |
+| `test_resume_identity_conflict_raises` | 账本里同 call_id 记录了不同参数 | `aresume` 抛 `ToolCallIdentityError` |
+| `test_resume_completed_returns_final` | `phase="completed"` | 立即 yield `FinalEvent(success=True)`，不再调用 LLM（FakeLLM 的调用计数为 0） |
+| `test_final_clears_state` | 正常跑完一轮 | `run_store.load()` 返回 `None` |
+| `test_stop_yields_interrupted_event` | `stop()` 后 | 事件流含 `InterruptedEvent(reason="user_stop")` 且 `messages` 非空；状态 `phase == "interrupted"` |
+| `test_cancel_persists_then_reraises` | 在 `astream` 消费中 `task.cancel()` | `run_state.json` 的 `phase == "interrupted"`，且 `CancelledError` 仍向上抛出 |
+| `test_stable_id_when_provider_omits_id` | FakeLLM 返回 `{"id": ""}` 的 tool_call | `ToolCallEvent.tool_call_id`、messages 里的 `tool_call_id`、账本里的 key **三者相同** 且非空 |
+| `test_end_to_end_no_duplicate_side_effect` | 跑 2 个 tool_call → 在第 2 个结果落账后杀掉 → `aresume` | `CounterTool.calls` 总长度 == 2（不是 3、不是 4） |
+
+`test_end_to_end_no_duplicate_side_effect` 是本 Subplan 的核心 AC，对应 master plan 的 AC-M3。
+
+### AC-4：整体门槛
+
+```bash
+pytest tests/test_reliability_run_state.py tests/test_react_agent_resume.py tests/test_reliability_call_identity.py tests/test_reliability_ledger.py -q
+git diff --name-only   # 应只含第 2 节 In scope 列出的文件
+```
+
+---
+
+## 6. no-scope-creep 边界
+
+改动文件白名单（`git status` 里不应出现白名单外的条目）：
+
+```
+agenticx/reliability/run_state.py          (新增)
+agenticx/reliability/__init__.py           (仅追加导出)
+agenticx/agents/react_agent_async.py       (修改)
+agenticx/agents/agent_events.py            (仅新增 InterruptedEvent 与联合类型)
+conclusions/agents_module_conclusion.md    (仅更新事件类型数量与新增能力描述)
+tests/test_reliability_run_state.py        (新增)
+tests/test_react_agent_resume.py           (新增)
+```
+
+明确禁止的顺手改动：
+- 不要「顺便」给 `ReActAgent` 加重试、加并发上限、加超时。
+- 不要动 `_execute_one_tool` 里的 offload 逻辑（`:195-209`）。
+- 不要动 `run()` 的同步封装报错文案（`:394-401`）。
+- 不要动 `agenticx/runtime/checkpoint.py` 去「统一两套 checkpoint」——两套并存是本阶段的有意设计，统一属于后续阶段。

--- a/.cursor/plans/2026-09-12-sdk-reliability-03-replay-safety.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-03-replay-safety.plan.md
@@ -1,0 +1,383 @@
+---
+name: sdk-reliability-03-replay-safety
+overview: 把"崩溃恢复后这个工具能不能重跑"从隐式判断变成显式的分层否决决策，并让每条否决都带可读理由。关键前提：仓库里已经存在副作用分级 agenticx/runtime/replay_ledger/effects.py::classify_tool_effect（EFFECT_CLASSES = none/read/local_write/external_write/unknown，未知一律 unknown 即 fail-closed），本 Subplan 复用它而不是另造一套分类法；但 agenticx/runtime/replay_ledger/__init__.py 目前 import store.py，而 store.py:42 import agenticx.studio.storage.factory，导致从 SDK 层引用 effects 会拉进 5 个 Studio 模块，破坏零耦合契约——必须先把该 __init__ 改成惰性导出（沿用 agenticx/runtime/__init__.py 已有的 __getattr__ 模式）。在此基础上新建 agenticx/reliability/replay_policy.py 实现分层否决，并给 BaseTool 加一个可选的 effect_class 声明位。
+todos:
+  - id: t1
+    content: 惰性化 replay_ledger/__init__.py，使 effects 可被 SDK 层无 Studio 耦合引用
+    status: pending
+  - id: t2
+    content: BaseTool 新增可选 effect_class 声明 + resolve_effect_class() 解析顺序
+    status: pending
+  - id: t3
+    content: 新建 agenticx/reliability/replay_policy.py（分层否决 + 可读理由）
+    status: pending
+  - id: t4
+    content: approve_unsafe_replay 逃生口（对已产出输出的调用无效）
+    status: pending
+  - id: t5
+    content: ReActAgent.aresume() 改为经 replay_policy 决策
+    status: pending
+  - id: t6
+    content: tests/test_reliability_replay_policy.py 全绿 + 零耦合校验
+    status: pending
+isProject: false
+---
+
+# Subplan 03：Replay 安全策略（分层否决）
+
+**Plan-Id**: `2026-09-12-sdk-reliability-03-replay-safety`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-03-replay-safety.plan.md`
+**Master**: `2026-09-12-sdk-reliability-kernel-master`
+**依赖**: Subplan 01（`CallLedger` / `Verdict`）、Subplan 02（`RunState.pending_calls` / `aresume`）
+**Planned-with**: Claude Opus 5
+**Suggested-Impl-Model**: Grok 4.6
+**Made-with**: Damon Li
+
+> **与 master plan 的偏差声明**：master §2 原写「`BaseTool.replay_safety`，取值 `idempotent|side_effecting|unknown`」。规划阶段核查代码后发现仓库已有 `EFFECT_CLASSES`（5 值）与 `classify_tool_effect()`，另造三值分类法会产生两套不可互转的语义。本 Subplan 改为**复用既有 5 值分类法**，属性名相应改为 `effect_class`。实施时同步修正 master plan §2 表格中的这一格。
+
+---
+
+## 1. 现状与根因
+
+### 1.1 副作用分级已经存在（不要重造）
+
+`agenticx/runtime/replay_ledger/contracts.py:17`：
+
+```python
+EFFECT_CLASSES = frozenset({"none", "read", "local_write", "external_write", "unknown"})
+```
+
+`agenticx/runtime/replay_ledger/effects.py:65-109` 的 `classify_tool_effect(tool_name, arguments)` 已经做到：
+
+- 内置只读工具白名单（`file_read`/`web_search`/`knowledge_search`/…）→ `"read"`
+- 本地写白名单（`file_write`/`file_edit`/`todo_write`/…）→ `"local_write"`
+- 外部写白名单（IM 发消息 / 邮件 / 日历 / 审批 / `git_push` / GitHub 写操作）→ `"external_write"`
+- `bash_exec` / `bash_bg_start` 走 `assess_command()` 深度判定：`/dev/tcp` 重定向、`external_publish`/`host_full_access`/`system_disruption`、`git push|fetch|pull` → `"external_write"`；动态重定向 → `"unknown"`；本地重定向/`touch|mkdir|mv|cp|tee`/`sed -i` → `"local_write"`
+- `mcp_call`、`computer_*`、`browser_click`/`browser_type` → `"unknown"`
+- **兜底 `return "unknown"`**（第 109 行）——已经是 fail-closed 姿态
+
+函数注释写得很清楚：`"""Classify a tool without claiming safety for unknown integrations."""`
+
+**结论：分类能力齐了，缺的是「拿分类做重放决策」的那一层。** 本 Subplan 只补决策层。
+
+### 1.2 但从 SDK 层引用它会破坏零耦合（必须先修）
+
+实测：
+
+```
+$ python -c "import sys; from agenticx.runtime.replay_ledger.effects import classify_tool_effect; print(len([m for m in sys.modules if m.startswith('agenticx.studio')]))"
+5
+```
+
+链路是：`from agenticx.runtime.replay_ledger.effects import ...` → 执行包 `__init__.py` → `agenticx/runtime/replay_ledger/__init__.py:17` `from ...store import ReplayLedgerStore` → `agenticx/runtime/replay_ledger/store.py:42` `from agenticx.studio.storage.factory import _default_sessions_root`。
+
+`effects.py` 本身只依赖 `agenticx.runtime.command_safety`（纯 `re`/`shlex`/`dataclasses`/`typing`，零耦合），**是包 `__init__` 把 Studio 拖进来的**。
+
+对照：`agenticx.runtime.interrupted_closers` 实测 0 个 Studio 模块，所以 Subplan 02 引用它是安全的；`replay_ledger` 这条路不安全。
+
+### 1.3 「能不能重跑」目前无人判断
+
+`agenticx/runtime/interrupted_closers.py` 只做到「告诉模型这次结果未知，你自己先只读核验」——是**概率性的自然语言约束**，不是机制。`replay_ledger` 的 `branchable` / `unbranchable_reason` 解决的是「能不能从这个历史事件分叉」，与「崩溃后这个已派发的工具能不能重跑」是两个不同问题（前者是用户主动操作的前向分支，后者是恢复时的被动决策），不能混用。
+
+上游 openai-agents-python 的做法值得参照：分层否决（`replay_safety` / `response_started` / `stateful_request` / `_hard_veto` / `_delegable_replay_veto`），加一个 `approve_unsafe_replay` 逃生口，且该逃生口**对流式已开始的请求无效**。我们要的是同一形状，但对齐我们自己的分类法。
+
+---
+
+## 2. In scope / Out of scope
+
+### In scope
+
+**新增：**
+- `agenticx/reliability/replay_policy.py`
+- `tests/test_reliability_replay_policy.py`
+
+**修改（仅这几处，逐行精确改）：**
+- `agenticx/runtime/replay_ledger/__init__.py`（把 `ReplayLedgerStore` 改为惰性 `__getattr__`；**不动** contracts 的那批导入）
+- `agenticx/tools/base.py`（`BaseTool` 新增一个类属性 + 一个 `resolve_effect_class()` 方法；**不动** `__init__` 签名、不动 `_validate_args`、不动 `run`/`arun`）
+- `agenticx/agents/react_agent_async.py`（`aresume()` 的判决分支改为调用 policy）
+- `agenticx/reliability/__init__.py`（追加导出）
+
+### Out of scope
+
+- **不改** `agenticx/runtime/replay_ledger/effects.py` 的任何分类规则、白名单、正则。想加工具就在业务侧用 `BaseTool.effect_class` 声明，不要往白名单里塞。
+- **不改** `agenticx/runtime/replay_ledger/store.py` / `recorder.py` / `branch_service.py` / `contracts.py`。
+- **不改** `agenticx/runtime/command_safety.py`（`assess_command` 是安全关键路径，本 Subplan 只读它的结论）。
+- **不改** `agenticx/runtime/agent_runtime.py`、不改 `agenticx/studio/**`。
+- 不做「用户在 UI 上确认要不要重跑」的交互（那是产品侧后续事项）；本 plan 只提供 `approve_unsafe_replay` 这个 API 级逃生口。
+- 不做分布式租约 / 跨进程 CAS。
+- 不新增第三方依赖。
+
+---
+
+## 3. t1：惰性化 `replay_ledger/__init__.py`
+
+**改法**：把第 17 行的 eager import 换成 `__getattr__`，与 `agenticx/runtime/__init__.py:23` 已经在用的模式完全一致（那里 `AgentRuntime` / `AgentTeamManager` 等十几个符号都是这么惰性化的，直接照抄形状）。
+
+**before**：
+```python
+from agenticx.runtime.replay_ledger.store import ReplayLedgerStore
+
+__all__ = [..., "ReplayLedgerStore", ...]
+```
+
+**after**：
+```python
+def __getattr__(name: str):
+    if name == "ReplayLedgerStore":
+        from agenticx.runtime.replay_ledger.store import ReplayLedgerStore
+
+        return ReplayLedgerStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [..., "ReplayLedgerStore", ...]   # __all__ 保持不变
+```
+
+`contracts` 的那 8 个符号继续 eager 导入（`contracts.py` 只依赖 `re`/`dataclasses`/`typing`，无害）。
+
+**为什么这不是 scope creep**：master plan 的 AC-M5 要求 `agenticx.reliability` 零 Studio 耦合。要么惰性化这一处（约 8 行，沿用既有模式），要么把分类逻辑复制一份到 `agenticx/reliability/`。复制会产生两份必然漂移的安全白名单——那才是真正的技术债。选前者。
+
+**必须验证既有调用方不破**：
+```bash
+rg -n "from agenticx.runtime.replay_ledger import|replay_ledger import ReplayLedgerStore" --glob '!**/__pycache__/**'
+pytest tests/test_replay_ledger_store.py tests/test_replay_ledger_recorder.py tests/test_run_replay_api.py tests/test_run_branch_api.py tests/test_run_branch_service.py tests/test_run_replay_export.py tests/test_run_context_checkpoint.py tests/test_run_workspace_snapshot.py tests/test_ha_checkpoint_resume.py tests/test_session_manager_persistence.py -q
+```
+以上测试**必须零修改通过**。`__getattr__` 惰性化对 `from X import Y` 和 `X.Y` 两种写法都透明，理论上无破坏；跑一遍是为了拿到证据，不是走形式。
+
+---
+
+## 4. t2：`BaseTool.effect_class`
+
+在 `agenticx/tools/base.py` 的 `BaseTool` 类体内（放在 `__init__` **之前**，与 `ToolError` 等定义同风格）新增：
+
+```python
+class BaseTool(ABC):
+    ...
+    #: Optional declaration of this tool's side-effect class, used by
+    #: ``agenticx.reliability.replay_policy`` to decide whether a call may be
+    #: re-executed after a crash. ``None`` means "no declaration" and falls
+    #: back to name/command based classification, which itself defaults to
+    #: ``"unknown"`` (fail-closed). Valid values: the members of
+    #: ``agenticx.runtime.replay_ledger.contracts.EFFECT_CLASSES``.
+    effect_class: Optional[str] = None
+
+    def resolve_effect_class(self, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Return the effective side-effect class for one invocation.
+
+        Resolution order (first hit wins):
+          1. this instance's / subclass's ``effect_class`` declaration
+          2. name & command based classification (``classify_tool_effect``)
+          3. ``"unknown"`` — never assume safety for an unrecognised tool
+        """
+```
+
+实现要点：
+- 声明值必须校验在 `EFFECT_CLASSES` 内；不在则 **抛 `ValueError`**（配错分类比不配更危险，不能静默降级）。
+- `classify_tool_effect` 用**函数内 import**，理由：`agenticx.tools.base` 是被广泛 import 的底层模块，模块级 import `agenticx.runtime.*` 会引入 `tools → runtime` 的方向依赖。这是 `no-inline-imports` 规则里明确允许的「有循环依赖理由且需注明」的例外，代码里写一行注释说明。
+- 分类结果**不缓存**：`bash_exec` 的分类依赖 `arguments["command"]`，缓存会串味。
+
+**不要做的事**：不要给现有任何工具类批量加 `effect_class` 声明。名字表已经覆盖了内置工具；逐个手工标注是后续独立事项，在这里做会让 diff 失控。
+
+---
+
+## 5. t3：`agenticx/reliability/replay_policy.py`
+
+### 5.1 决策输入
+
+```python
+@dataclass(frozen=True)
+class ReplayRequest:
+    """Everything needed to decide whether one interrupted call may re-run."""
+
+    call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    ledger_verdict: "Verdict"          # from Subplan 01
+    effect_class: str                  # from BaseTool.resolve_effect_class()
+    output_already_emitted: bool = False   # a FinalEvent / token stream已发给用户
+    request_is_streaming: bool = False     # 本轮走的是流式请求
+    approve_unsafe_replay: bool = False    # 调用方显式授权
+```
+
+### 5.2 决策输出
+
+```python
+ReplayAction = Literal["replay", "skip_use_recorded", "mark_unknown", "abort"]
+
+
+@dataclass(frozen=True)
+class ReplayDecision:
+    action: ReplayAction
+    veto: str | None            # 命中的否决层名；None 表示允许重跑
+    reason: str                 # 面向人的一句话理由（进日志与 tool 消息）
+    approved_override: bool = False   # 是否靠 approve_unsafe_replay 放行
+```
+
+四个动作的含义：
+
+| action | 做什么 |
+|---|---|
+| `replay` | 重新执行该工具 |
+| `skip_use_recorded` | 不执行，直接用账本里记录的结果补 tool 消息行 |
+| `mark_unknown` | 不执行，补一条「结果未知，先只读核验」的 tool 行（复用 `OUTCOME_UNKNOWN_CONTENT`） |
+| `abort` | 不可恢复，抛异常终止恢复流程 |
+
+### 5.3 分层否决（严格按此顺序，短路返回）
+
+```python
+def decide_replay(req: ReplayRequest) -> ReplayDecision:
+```
+
+| 序 | 否决层名 | 触发条件 | action | 可否被 approve 覆盖 |
+|---|---|---|---|---|
+| 1 | `identity_conflict` | `ledger_verdict is Verdict.IDENTITY_CONFLICT` | `abort` | **否** |
+| 2 | `output_already_emitted` | `req.output_already_emitted` | `mark_unknown` | **否**（对齐上游：流式已开始则逃生口无效） |
+| 3 | `streaming_request` | `req.request_is_streaming and not req.output_already_emitted` 且 verdict 为 `AMBIGUOUS` | `mark_unknown` | **否** |
+| 4 | `recorded_result_available` | `ledger_verdict is Verdict.REPLAY_SKIP` | `skip_use_recorded` | n/a（这是好路径，不是否决） |
+| 5 | `external_side_effect` | `effect_class == "external_write"` 且 verdict 为 `AMBIGUOUS` | `mark_unknown` | 是 |
+| 6 | `unknown_side_effect` | `effect_class == "unknown"` 且 verdict 为 `AMBIGUOUS` | `mark_unknown` | 是 |
+| 7 | `local_write_ambiguous` | `effect_class == "local_write"` 且 verdict 为 `AMBIGUOUS` | `mark_unknown` | 是 |
+| — | （无否决） | verdict 为 `FRESH`；或 verdict 为 `AMBIGUOUS` 且 `effect_class in {"none","read"}` | `replay` | n/a |
+
+**层 1/2/3 是 hard veto**：即使 `approve_unsafe_replay=True` 也照旧否决，且返回的 `ReplayDecision.reason` 必须说明「授权已被忽略，因为 <理由>」，不能静默忽略用户的授权（用户会以为生效了）。
+
+**层 5/6/7 被 approve 覆盖时**：返回 `ReplayDecision(action="replay", veto=<原否决层名>, reason="调用方显式授权重放（原否决：…）", approved_override=True)`。保留 `veto` 字段是为了审计——事后要能查出哪些重放是被人工放行的。
+
+**`FRESH` 为什么无条件 replay**：账本证明这次调用**没有成功派发**（`record_dispatch` 在 `asyncio.gather` 之前、且带 fsync，见 Subplan 01）。没派发就没副作用，重跑安全。这是整套机制成立的支点，代码里写注释标明。
+
+### 5.4 理由文案
+
+`reason` 必须是可直接给人看的中文短句，且**包含工具名**。示例（照抄）：
+
+- `identity_conflict` → `f"工具 {tool_name} 的调用 {call_id} 参数与账本记录不一致，无法安全恢复"`
+- `output_already_emitted` → `f"本轮输出已发给用户，不能重跑 {tool_name}（授权已忽略）"`
+- `external_side_effect` → `f"{tool_name} 会产生外部副作用且执行结果未知，已跳过重跑"`
+- `unknown_side_effect` → `f"{tool_name} 的副作用未知（未声明 effect_class），保守跳过重跑"`
+- `recorded_result_available` → `f"{tool_name} 已在中断前完成，复用已记录结果"`
+- 无否决 → `f"{tool_name} 未成功派发，可安全重跑"` / `f"{tool_name} 为只读操作，可安全重跑"`
+
+这批文案直接支撑 master plan 的 AC-M4（错误可诊断率）。
+
+---
+
+## 6. t5：接入 `aresume()`
+
+把 Subplan 02 第 5 节 `aresume()` 里 `phase == "tools_dispatched"` 那段的**判决部分**替换为：
+
+```python
+for pc in state.pending_calls:
+    verdict = ledger.reconcile_safe(pc.call_id, pc.tool_name, pc.arguments) if ledger else Verdict.AMBIGUOUS
+    tool = self._tools_by_name.get(pc.tool_name)
+    effect = tool.resolve_effect_class(pc.arguments) if tool is not None else "unknown"
+    decision = decide_replay(ReplayRequest(
+        call_id=pc.call_id,
+        tool_name=pc.tool_name,
+        arguments=pc.arguments,
+        ledger_verdict=verdict,
+        effect_class=effect,
+        output_already_emitted=state.phase == "completed",
+        request_is_streaming=True,          # ReActAgent.astream 始终流式
+        approve_unsafe_replay=approve_unsafe_replay,
+    ))
+    # 按 decision.action 分派：replay / skip_use_recorded / mark_unknown / abort
+```
+
+`aresume()` 新增 keyword-only 参数 `approve_unsafe_replay: bool = False`。
+
+`mark_unknown` 分支写入的 tool 消息行，`content` 用 `decision.reason` **加** `OUTCOME_UNKNOWN_CONTENT`（先说具体原因，再给通用的只读核验指引），`metadata` 带 `{"kind": KIND_OUTCOME_UNKNOWN, "veto": decision.veto}`。
+
+`abort` 分支抛 `ToolCallIdentityError`（Subplan 01 已定义）。
+
+**注意**：`self._tools_by_name` 若 `ReActAgent` 里没有这个映射，用现有的工具查找方式（读 `react_agent_async.py` 里 `_execute_one_tool` 怎么找工具的，照同一路径），不要新建索引结构。
+
+---
+
+## 7. 验收标准
+
+### AC-1：零耦合（最硬的一条，先跑）
+
+```bash
+python -c "
+import sys
+from agenticx.reliability.replay_policy import decide_replay
+bad = sorted(m for m in sys.modules if m.startswith('agenticx.studio'))
+assert not bad, bad
+print('OK, agenticx modules:', len([m for m in sys.modules if m.startswith('agenticx')]))
+"
+```
+必须退出码 0。这是 t1 惰性化是否成功的唯一判据。
+
+### AC-2：既有 replay_ledger 测试零修改通过
+
+见第 3 节的 pytest 命令，10 个测试文件全绿。
+
+### AC-3：`tests/test_reliability_replay_policy.py`
+
+| 测试名 | 断言 |
+|---|---|
+| `test_fresh_always_replays` | `FRESH` + 任意 `effect_class`（含 `external_write`）→ `action == "replay"`，`veto is None` |
+| `test_replay_skip_uses_recorded` | `REPLAY_SKIP` → `action == "skip_use_recorded"` |
+| `test_identity_conflict_aborts` | `IDENTITY_CONFLICT` → `action == "abort"`，`veto == "identity_conflict"` |
+| `test_identity_conflict_ignores_approval` | 同上 + `approve_unsafe_replay=True` → 仍 `abort`；`reason` 含「已忽略」 |
+| `test_output_emitted_hard_veto` | `AMBIGUOUS` + `output_already_emitted=True` + `approve=True` + `effect_class="read"` → `mark_unknown`，`approved_override is False` |
+| `test_ambiguous_read_replays` | `AMBIGUOUS` + `effect_class="read"` → `replay` |
+| `test_ambiguous_none_replays` | `AMBIGUOUS` + `effect_class="none"` → `replay` |
+| `test_ambiguous_external_write_marks_unknown` | `AMBIGUOUS` + `external_write` → `mark_unknown`，`veto == "external_side_effect"` |
+| `test_ambiguous_unknown_marks_unknown` | `AMBIGUOUS` + `unknown` → `mark_unknown`，`veto == "unknown_side_effect"` |
+| `test_ambiguous_local_write_marks_unknown` | `AMBIGUOUS` + `local_write` → `mark_unknown` |
+| `test_approval_overrides_soft_veto` | `AMBIGUOUS` + `external_write` + `approve=True` + `output_already_emitted=False` + `request_is_streaming=False` → `replay`，`approved_override is True`，`veto == "external_side_effect"`（保留审计痕迹） |
+| `test_reason_contains_tool_name` | 遍历上述所有分支，断言 `tool_name in decision.reason` |
+| `test_veto_order_identity_before_output` | 同时构造 `IDENTITY_CONFLICT` + `output_already_emitted=True` → `veto == "identity_conflict"`（顺序不能反） |
+
+### AC-4：`resolve_effect_class` 解析顺序
+
+在同一测试文件内：
+
+| 测试名 | 断言 |
+|---|---|
+| `test_declared_effect_class_wins` | 子类声明 `effect_class = "read"` 但工具名叫 `send_email` → 解析结果 `"read"` |
+| `test_falls_back_to_classifier` | 未声明 + `name="file_read"` → `"read"`；`name="git_push"` → `"external_write"` |
+| `test_bash_exec_uses_command` | 未声明 + `name="bash_exec"` + `{"command": "git push origin main"}` → `"external_write"`；`{"command": "ls -la"}` → `"read"` |
+| `test_unknown_tool_is_unknown` | 未声明 + `name="my_custom_thing"` → `"unknown"` |
+| `test_invalid_declaration_raises` | 声明 `effect_class = "totally_bogus"` → `resolve_effect_class()` 抛 `ValueError` |
+
+### AC-5：端到端（接 Subplan 02 的测试）
+
+在 `tests/test_react_agent_resume.py` 追加：
+
+| 测试名 | 断言 |
+|---|---|
+| `test_resume_external_write_not_replayed` | `CounterTool` 声明 `effect_class = "external_write"`，账本状态为 `dispatched`（结果未知）→ `aresume` 后计数器**不变**，messages 里出现含 `external_side_effect` veto 的 tool 行 |
+| `test_resume_read_tool_replayed` | 同场景但声明 `effect_class = "read"` → 计数器 +1 |
+| `test_resume_with_approval_replays` | `external_write` + `aresume(approve_unsafe_replay=True)` → 计数器 +1 |
+
+### AC-6：整体
+
+```bash
+pytest tests/test_reliability_replay_policy.py tests/test_react_agent_resume.py tests/test_reliability_ledger.py tests/test_reliability_call_identity.py tests/test_reliability_run_state.py -q
+git diff --name-only    # 与第 2 节 In scope 逐条对齐
+```
+
+---
+
+## 8. no-scope-creep 边界
+
+改动文件白名单：
+
+```
+agenticx/reliability/replay_policy.py                 (新增)
+agenticx/reliability/__init__.py                      (仅追加导出)
+agenticx/runtime/replay_ledger/__init__.py            (仅惰性化 ReplayLedgerStore 一处)
+agenticx/tools/base.py                                (仅新增 effect_class 属性 + resolve_effect_class 方法)
+agenticx/agents/react_agent_async.py                  (仅 aresume 判决分支 + 新增 approve_unsafe_replay 参数)
+tests/test_reliability_replay_policy.py               (新增)
+tests/test_react_agent_resume.py                      (追加 AC-5 的 3 个测试)
+.cursor/plans/2026-09-12-sdk-reliability-kernel-master.plan.md  (修正 §2 表格中 replay_safety → effect_class)
+```
+
+明确禁止：
+- 不要给 `effects.py` 的白名单加工具名——哪怕只加一个。
+- 不要「顺便」把 `replay_ledger` 的 `branchable` 逻辑和本 plan 的否决层统一——两者语义不同（前向分叉 vs 恢复重放），强行统一会引入错误。
+- 不要动 `command_safety.py`。
+- 不要给现有工具类批量标注 `effect_class`。
+- 不要在 `agenticx/tools/base.py` 里做模块级 `import agenticx.runtime.*`（会引入方向反了的依赖），只能函数内 import 并注明理由。

--- a/.cursor/plans/2026-09-12-sdk-reliability-04-fault-injection-bench.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-04-fault-injection-bench.plan.md
@@ -1,0 +1,465 @@
+---
+name: sdk-reliability-04-fault-injection-bench
+overview: 把"更可靠"变成四个可复现的数字。仓库已有完整评测骨架（agenticx/evaluation/：EvalSet/EvalCase/EvalResult/EvalSummary + TrajectoryMatcher + EvalRunner），但它只度量正确性，没有任何故障注入；且 EvalRunner._execute_with_agent 是 duck-type 在 execute_async(query=, context=) 上的示意代码，与 ReActAgent.arun 不兼容。本 Subplan 新建 agenticx/evaluation/fault_injection.py（确定性故障注入 + 副作用计数 oracle）与 agenticx/evaluation/reliability_runner.py（直接驱动 ReActAgent 的姊妹 runner，复用 EvalSet/EvalResult/TrajectoryMatcher 数据模型，不改 EvalRunner），产出重复副作用率、崩溃恢复成功率、历史一致率、错误可诊断率四项指标与可复现报告。
+todos:
+  - id: t1
+    content: 新建 fault_injection.py：FaultSpec / 六种故障点 / FaultInjector
+    status: pending
+  - id: t2
+    content: SideEffectCounter oracle（确定性可数副作用工具）
+    status: pending
+  - id: t3
+    content: ReliabilityCase / ReliabilityMetrics 数据模型（复用 EvalSet 家族）
+    status: pending
+  - id: t4
+    content: ReliabilityRunner：注入 → 崩溃 → aresume → 判定
+    status: pending
+  - id: t5
+    content: 四项指标计算与 to_report()
+    status: pending
+  - id: t6
+    content: 内置基准用例集 + tests/test_reliability_bench.py 全绿
+    status: pending
+isProject: false
+---
+
+# Subplan 04：故障注入可靠性基准
+
+**Plan-Id**: `2026-09-12-sdk-reliability-04-fault-injection-bench`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-04-fault-injection-bench.plan.md`
+**Master**: `2026-09-12-sdk-reliability-kernel-master`
+**依赖**: Subplan 01、02、03 全部完成
+**Planned-with**: Claude Opus 5
+**Suggested-Impl-Model**: Grok 4.6
+**Made-with**: Damon Li
+
+---
+
+## 1. 现状与根因
+
+### 1.1 评测骨架已经存在，但只量正确性
+
+`agenticx/evaluation/` 现有 7 个模块：
+
+| 文件 | 提供什么 |
+|---|---|
+| `evalset.py` | `ExpectedToolUse` / `EvalCase` / `EvalResult` / `EvalSummary` / `EvalSet`（Pydantic `BaseModel`，含 `from_file`/`to_file`/`to_report`） |
+| `trajectory_matcher.py` | `MatchMode`（EXACT/PARTIAL/UNORDERED）/ `TrajectoryMatcher` / `ToolCall` / `match_trajectory` |
+| `runner.py` | `EvalRunner`（并发信号量、超时、回调、汇总） |
+| `llm_judge.py` | `LLMJudge` / `CompositeJudge` / `MockLLMProvider` |
+| `span_evaluator.py` | `SpanEvaluator` |
+| `trace_converter.py` | `TraceToEvalSetConverter` |
+
+`rg -n "fault|inject|crash|kill" agenticx/evaluation/` **零命中**。整套体系度量的是「工具调用轨迹对不对、回答好不好」，**完全不度量「崩了会怎样」**。
+
+**所以本 Subplan 复用数据模型，不重造评测框架。**
+
+### 1.2 但 `EvalRunner` 无法直接驱动 `ReActAgent`
+
+`agenticx/evaluation/runner.py:261-291`：
+
+```python
+    async def _execute_with_agent(self, case: EvalCase) -> Dict[str, Any]:
+        # 这里需要根据实际的 AgentExecutor 接口实现
+        # 以下是示意代码
+        ...
+        if hasattr(self.agent_executor, 'execute_async'):
+            result = await self.agent_executor.execute_async(
+                query=case.query,
+                context=case.initial_context
+            )
+```
+
+它 duck-type 在 `execute_async(query=, context=)` 上，而 `ReActAgent` 的接口是 `arun(query, history=...)` / `astream(...)`（`agenticx/agents/react_agent_async.py:343`、`:220`）。两者不兼容，且注释自己写明是示意代码。
+
+改 `EvalRunner` 去适配 `ReActAgent` 会动到一个被 `tests/` 依赖的既有类，风险与收益不成比例。**建姊妹 runner，`EvalRunner` 一行不动。**
+
+### 1.3 可靠性无法自证
+
+master plan 承诺的四个数字（重复副作用率、崩溃恢复成功率、历史一致率、错误可诊断率）现在**一个都测不出来**。Subplan 01–03 做完后机制存在了，但没有度量手段就无法对外声称领先，也无法在 Subplan 05 判断「翻默认值到底有没有用」。本 Subplan 是整个第一阶段的**验收仪器**。
+
+---
+
+## 2. In scope / Out of scope
+
+### In scope
+
+**新增：**
+- `agenticx/evaluation/fault_injection.py`
+- `agenticx/evaluation/reliability_runner.py`
+- `agenticx/evaluation/benchmarks/reliability_v1.json`（内置基准用例集，`EvalSet` 格式）
+- `tests/test_reliability_bench.py`
+
+**修改：**
+- `agenticx/evaluation/__init__.py`（仅追加导出）
+
+### Out of scope
+
+- **不改** `agenticx/evaluation/runner.py`（`EvalRunner` 一行不动）。
+- **不改** `evalset.py` / `trajectory_matcher.py` / `llm_judge.py` / `span_evaluator.py` / `trace_converter.py`。若 `ReliabilityCase` 需要额外字段，用 `EvalCase.metadata`（已有的 `Dict[str, Any]` 字段）承载，**不给 `EvalCase` 加字段**。
+- **不改** `agenticx/reliability/**`（Subplan 01–03 的产物在这里只被使用，不被修改；如果基准跑出来发现内核有 bug，回到对应 Subplan 修，不在这里打补丁）。
+- **不改** `agenticx/agents/**`、`agenticx/runtime/**`、`agenticx/studio/**`。
+- 不做真进程级 kill（`os.kill` / 子进程）。故障注入全部在**进程内模拟**：在指定边界抛特定异常 + 丢弃内存态 + 重建 agent 从磁盘 `aresume`。理由：真 kill 让测试变慢、变 flaky、且 CI 上难复现；进程内模拟已经能覆盖「内存态丢失、磁盘态是唯一真相」这个核心风险面。**这一点必须在报告里如实标注**，不要在对外材料里把它说成真崩溃演练。
+- 不接真实 LLM。全部用确定性 FakeLLM（预设 tool_call 脚本）。基准必须**离线可跑、结果可复现**。
+- 不做与上游 openai-agents-python 的横向对比跑分（那需要装它们的包、要真 API key，属后续独立事项）。本 Subplan 只产出 AgenticX 自己的绝对数字。
+- 不新增第三方依赖。
+- 不做性能/延迟基准。
+
+---
+
+## 3. `agenticx/evaluation/fault_injection.py`
+
+### 3.1 故障点枚举
+
+```python
+class FaultKind(str, Enum):
+    """Where a deterministic fault is injected during one run."""
+
+    KILL_BEFORE_TOOL_RESULT = "kill_before_tool_result"
+    KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST = "kill_after_tool_result_before_persist"
+    PERSIST_FAILURE = "persist_failure"
+    LLM_TIMEOUT_MID_STREAM = "llm_timeout_mid_stream"
+    DUPLICATE_TOOL_CALL_ID = "duplicate_tool_call_id"
+    CHANGED_ARGS_SAME_ID = "changed_args_same_id"
+```
+
+每种故障要注入在哪、期望系统怎么表现：
+
+| FaultKind | 注入点 | 期望行为（判定依据） |
+|---|---|---|
+| `KILL_BEFORE_TOOL_RESULT` | 工具已派发（账本已 `record_dispatch`），结果返回前抛 `_InjectedCrash` | `aresume` 后：`external_write`/`unknown` 类工具**不重跑**（副作用计数不增），补 `mark_unknown` 行；`read` 类可重跑 |
+| `KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST` | 工具已返回、`record_result` 已 fsync，但 `RunStateStore.save` 之前崩 | `aresume` 后判决 `REPLAY_SKIP`，**副作用计数不增**，且 messages 里的 tool 行内容 == 崩溃前的真实结果 |
+| `PERSIST_FAILURE` | monkeypatch `RunStateStore.save` 抛 `OSError`（模拟磁盘满/只读） | 异常必须**向上抛出**（不得被吞），且用户可见的错误信息里能定位到是持久化失败 |
+| `LLM_TIMEOUT_MID_STREAM` | FakeLLM 在产出部分 token 后抛 `asyncio.TimeoutError` | 状态落在 `before_llm` 或 `interrupted`；`aresume` 后能继续，且**不重复执行任何工具** |
+| `DUPLICATE_TOOL_CALL_ID` | FakeLLM 在同一轮返回两个 `id` 相同、参数**也相同**的 tool_call | 第二个走 `REPLAY_SKIP`，副作用计数只 +1 |
+| `CHANGED_ARGS_SAME_ID` | FakeLLM 返回与账本已有记录同 `id` 但参数不同的 tool_call | 抛 `ToolCallIdentityError`，错误信息含 call_id 与变化字段名（对齐 Subplan 01 的 AC-M4） |
+
+### 3.2 `FaultSpec` 与 `FaultInjector`
+
+```python
+@dataclass(frozen=True)
+class FaultSpec:
+    kind: FaultKind
+    #: 1-based index of the tool call at which to fire (0 = fire on the first
+    #: matching boundary regardless of index).
+    at_call_index: int = 1
+    #: Fire only when the dispatched tool has this name; None = any tool.
+    tool_name: str | None = None
+
+
+class _InjectedCrash(BaseException):
+    """Simulated process death.
+
+    Deliberately derives from BaseException, not Exception, so that ordinary
+    ``except Exception`` handlers inside the agent cannot swallow it — a real
+    process kill is not catchable either.
+    """
+
+
+class FaultInjector:
+    """Deterministic, single-shot fault injection around a ReActAgent run."""
+
+    def __init__(self, spec: FaultSpec) -> None: ...
+
+    def should_fire(self, *, boundary: str, call_index: int, tool_name: str) -> bool:
+        """True at most once per injector instance."""
+
+    @property
+    def fired(self) -> bool: ...
+```
+
+**`_InjectedCrash` 继承 `BaseException` 是关键设计**：`ReActAgent._execute_one_tool` 与 `astream` 里有 `except Exception` 块，如果注入的异常继承 `Exception`，会被当成普通工具失败处理掉，测出来的就不是崩溃恢复而是错误处理。代码里写注释说明这一点。
+
+`should_fire` 必须**单次触发**（`self._fired` 标志），否则 `aresume` 之后会二次崩溃，测试变成死循环。
+
+### 3.3 副作用 oracle
+
+```python
+class SideEffectCounter:
+    """Process-local, deterministic side-effect ledger used as the bench oracle.
+
+    A "side effect" here is one append to ``self.records``. Because the bench
+    runs offline with no real external calls, this counter IS the ground truth
+    for "did we do it twice".
+    """
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []   # (op_key, payload_digest)
+
+    def apply(self, op_key: str, payload: dict) -> str:
+        """Record one effect and return a deterministic result string."""
+
+    @property
+    def duplicate_count(self) -> int:
+        """Number of records beyond the first for any repeated op_key."""
+
+
+class CountingTool(BaseTool):
+    """BaseTool wrapper around SideEffectCounter, used by bench cases.
+
+    ``effect_class`` is settable per instance so one case can exercise the
+    read / local_write / external_write / unknown branches of
+    agenticx.reliability.replay_policy.
+    """
+```
+
+`duplicate_count` 的定义必须精确：按 `op_key` 分组，`sum(max(0, len(group) - 1))`。这是「重复副作用率」的分子。
+
+---
+
+## 4. `agenticx/evaluation/reliability_runner.py`
+
+### 4.1 用例模型（复用 `EvalCase`，不改它）
+
+```python
+@dataclass(frozen=True)
+class ReliabilityCase:
+    """One fault-injection scenario.
+
+    Serialises into a standard ``EvalCase`` whose ``metadata`` carries the
+    fault spec, so a reliability benchmark is still a plain EvalSet on disk
+    and can be loaded by EvalSet.from_file().
+    """
+
+    id: str
+    query: str
+    fault: FaultSpec
+    #: FakeLLM script: list of rounds, each round a list of
+    #: {"id": str, "name": str, "arguments": dict} or {"final": str}
+    llm_script: list[list[dict[str, Any]]]
+    tool_effect_class: str = "external_write"
+    expected_total_effects: int = 1
+    expect_resume_success: bool = True
+    expect_error_diagnosable: bool = False
+
+    def to_eval_case(self) -> "EvalCase": ...
+    @classmethod
+    def from_eval_case(cls, case: "EvalCase") -> "ReliabilityCase": ...
+```
+
+`to_eval_case()` 把 `fault` / `llm_script` / 各 `expect_*` 塞进 `EvalCase.metadata["reliability"]`。这样 `agenticx/evaluation/benchmarks/reliability_v1.json` 就是一个合法 `EvalSet`，能被既有 `EvalSet.from_file()` 读，也能被既有工具链看见——**不引入第二种磁盘格式**。
+
+### 4.2 指标
+
+```python
+@dataclass
+class ReliabilityMetrics:
+    """The four numbers that define "AgenticX SDK leads on reliability"."""
+
+    total_cases: int
+    #: 分子 = 各用例 SideEffectCounter.duplicate_count 之和
+    #: 分母 = 各用例 expected_total_effects 之和
+    duplicate_side_effect_rate: float
+    #: 分子 = aresume 后成功走到 FinalEvent 且未抛未预期异常的用例数
+    #: 分母 = expect_resume_success is True 的用例数
+    crash_recovery_success_rate: float
+    #: 分子 = 恢复后 messages 通过一致性校验的用例数（见 4.4）
+    #: 分母 = 成功恢复的用例数
+    history_consistency_rate: float
+    #: 分子 = 失败/否决路径上，用户可见文本同时包含工具名与具体原因的用例数
+    #: 分母 = 预期产生失败/否决的用例数
+    error_diagnosability_rate: float
+
+    per_case: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_report(self) -> str:
+        """Markdown report; mirrors EvalSummary.to_report() style."""
+```
+
+四个指标的**方向性**必须在 `to_report()` 里写清楚，避免读者误读：
+
+- `duplicate_side_effect_rate`：**越低越好**，目标 `0.0`
+- `crash_recovery_success_rate`：**越高越好**，目标 `1.0`
+- `history_consistency_rate`：**越高越好**，目标 `1.0`
+- `error_diagnosability_rate`：**越高越好**，目标 `1.0`
+
+`to_report()` 还必须包含一段**方法论声明**（原文照写，不要美化）：
+
+> 本基准为**进程内模拟崩溃**（在指定边界抛不可捕获异常并丢弃内存态，从磁盘状态重建），非真实进程 kill。指标反映"内存态丢失后磁盘态能否独立支撑正确恢复"，不覆盖 OS 级页缓存丢失、磁盘损坏等物理故障。
+
+### 4.3 执行流程
+
+```python
+class ReliabilityRunner:
+    """Drives ReActAgent through fault-injection cases.
+
+    Sibling of EvalRunner (which is duck-typed on execute_async and cannot
+    drive ReActAgent); reuses EvalSet/EvalCase/EvalResult data models and
+    TrajectoryMatcher, but owns its own execution loop.
+    """
+
+    def __init__(self, *, root: Path, verbose: bool = False) -> None: ...
+
+    async def run_case_async(self, case: ReliabilityCase) -> dict[str, Any]: ...
+    async def run_async(self, evalset: "EvalSet") -> ReliabilityMetrics: ...
+    def run(self, evalset: "EvalSet") -> ReliabilityMetrics: ...
+```
+
+单个用例的执行流程（**严格按此顺序**，每一步都是判定点）：
+
+```
+1. 建 tmp 目录：<root>/<case.id>/
+2. counter = SideEffectCounter(); tool = CountingTool(counter, effect_class=case.tool_effect_class)
+3. ledger = CallLedger(session_id=case.id, root=...)
+   run_store = RunStateStore(session_id=case.id, root=...)
+   llm = ScriptedFakeLLM(case.llm_script)
+   agent = ReActAgent(llm=llm, tools=[tool], run_store=run_store, call_ledger=ledger)
+4. injector = FaultInjector(case.fault)  并挂到 agent 的注入钩子上
+5. phase_1 = 消费 agent.astream(case.query)，捕获 _InjectedCrash / OSError / TimeoutError
+   - 记录：crashed(bool)、crash_exc、phase_1 事件序列
+6. 丢弃全部内存态：del agent, ledger, run_store   （模拟进程死亡）
+7. 重建（只从磁盘）：
+   ledger2 = CallLedger(session_id=case.id, root=...)   # 会 load 已有 jsonl
+   store2  = RunStateStore(session_id=case.id, root=...)
+   agent2  = ReActAgent(llm=ScriptedFakeLLM(case.llm_script), tools=[tool],
+                        run_store=store2, call_ledger=ledger2)
+   注意：tool 与 counter 沿用同一实例——副作用计数必须跨"进程"累计，
+        否则测不出重复副作用（这是本 Subplan 最容易写错的一步）
+8. phase_2 = 消费 agent2.aresume()，捕获异常
+9. 判定：
+   - effects_total = len(counter.records)
+   - duplicates = counter.duplicate_count
+   - resume_ok = phase_2 里出现 FinalEvent(success=True) 且无未预期异常
+   - history_ok = 见 4.4
+   - diagnosable = 见 4.5
+```
+
+**第 7 步的 `tool`/`counter` 复用是本 Subplan 的核心 trick**，注释里必须写明理由：真实世界里外部副作用（发出去的消息、写下的文件）不会随进程死亡而回滚，所以 oracle 也不能重置。
+
+`ScriptedFakeLLM` 在 `fault_injection.py` 里实现，接口对齐 `ReActAgent` 期望的 `_ainvoke` 契约（读 `react_agent_async.py:_ainvoke` 实际怎么调 llm，照它的形状实现，不要猜）。
+
+### 4.4 历史一致性校验
+
+`history_ok` 为 True 需**同时**满足（逐条断言，任一不满足即为 False）：
+
+1. 每个 `assistant` 消息里的每个 `tool_calls[i].id`，在后续 `messages` 中都有**恰好一条** `role == "tool"` 且 `tool_call_id` 相同的行（不多不少）。
+2. 没有任何 `tool_call_id` 为空串或 `None` 的 `tool` 行。
+3. `tool` 行的相对顺序与对应 `assistant.tool_calls` 的顺序一致。
+4. 没有连续两条 `role == "assistant"` 且中间夹着未闭合的 `tool_calls`。
+
+这四条正是 `agenticx/runtime/agent_runtime.py` 花大量代码在 Studio 侧维护的「provider 400 防护」不变量（见 `conclusions/runtime_module_conclusion.md`）。SDK 侧必须自己达标。
+
+### 4.5 错误可诊断性判定
+
+对 `expect_error_diagnosable is True` 的用例，收集所有「用户可见文本」：`ErrorEvent.message`、`mark_unknown` 分支写入的 tool 行 `content`、向上抛出的异常的 `str()`。
+
+`diagnosable` 为 True 需满足：
+1. 文本非空，且**不是**裸类型名（排除 `"'_type'"`、`"KeyError"`、`"OSError"` 这类单 token —— 这是用户明确反馈过的坏体验）；
+2. 包含涉事**工具名**；
+3. 包含一个具体原因短语（`veto` 名或「持久化失败」「参数不一致」等）。
+
+实现一个 `_is_diagnosable(text: str, *, tool_name: str) -> bool` 辅助函数并单独测它。
+
+### 4.6 内置基准用例集
+
+`agenticx/evaluation/benchmarks/reliability_v1.json`，`EvalSet` 格式，`name = "agenticx-reliability-v1"`，**至少 12 个用例**，覆盖矩阵：
+
+| # | FaultKind | tool_effect_class | expected_total_effects | expect_resume_success | expect_error_diagnosable |
+|---|---|---|---|---|---|
+| 1 | `KILL_BEFORE_TOOL_RESULT` | `external_write` | 1 | True | True |
+| 2 | `KILL_BEFORE_TOOL_RESULT` | `read` | 2 | True | False |
+| 3 | `KILL_BEFORE_TOOL_RESULT` | `unknown` | 1 | True | True |
+| 4 | `KILL_BEFORE_TOOL_RESULT` | `local_write` | 1 | True | True |
+| 5 | `KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST` | `external_write` | 1 | True | False |
+| 6 | `KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST` | `local_write` | 1 | True | False |
+| 7 | `PERSIST_FAILURE` | `read` | 1 | False | True |
+| 8 | `LLM_TIMEOUT_MID_STREAM` | `external_write` | 1 | True | False |
+| 9 | `LLM_TIMEOUT_MID_STREAM` | `read` | 1 | True | False |
+| 10 | `DUPLICATE_TOOL_CALL_ID` | `external_write` | 1 | True | False |
+| 11 | `CHANGED_ARGS_SAME_ID` | `external_write` | 1 | False | True |
+| 12 | 多轮：2 工具，第 2 个后崩 | `external_write` | 2 | True | False |
+
+用例 2 的 `expected_total_effects = 2` 是**有意的**：`read` 类工具允许重跑，所以计数会到 2，但这**不算 duplicate**——`duplicate_side_effect_rate` 的分子只统计 `counter.duplicate_count`（同 `op_key` 重复），而重跑用的 `op_key` 应与原调用相同，所以会被算成 duplicate。**这里有个设计决策**：`read` 类工具重跑属预期行为，不应污染重复副作用率。解决办法：`CountingTool` 在 `effect_class == "read"` 时**不**写入 `counter.records`，改写入 `counter.reads`（另一个列表）。`duplicate_count` 只看 `records`。实施时按此办，并在 `SideEffectCounter` 的 docstring 里写明。
+
+### 4.7 `__init__.py` 追加导出
+
+```python
+from .fault_injection import (
+    FaultKind, FaultSpec, FaultInjector, SideEffectCounter, CountingTool, ScriptedFakeLLM,
+)
+from .reliability_runner import ReliabilityCase, ReliabilityMetrics, ReliabilityRunner
+```
+并加入 `__all__`。**保持现有导出顺序与内容不变，只在末尾追加。**
+
+---
+
+## 5. 验收标准
+
+### AC-1：`tests/test_reliability_bench.py` — 组件级
+
+| 测试名 | 断言 |
+|---|---|
+| `test_injector_fires_once` | `should_fire` 连续调用 5 次只有第 1 次返回 True；`fired` 变 True |
+| `test_injector_respects_call_index` | `at_call_index=2` → 第 1 次 False、第 2 次 True |
+| `test_injector_respects_tool_name` | `tool_name="bump"` → 别的工具名不触发 |
+| `test_injected_crash_not_caught_by_except_exception` | `try: raise _InjectedCrash() except Exception: pytest.fail()` 能穿透 |
+| `test_counter_duplicate_count` | 同 `op_key` 写 3 次 → `duplicate_count == 2`；不同 key 各 1 次 → `0` |
+| `test_counter_read_not_counted` | `effect_class="read"` 的 `CountingTool` 调 3 次 → `duplicate_count == 0`，`len(counter.reads) == 3` |
+| `test_reliability_case_roundtrip` | `ReliabilityCase.from_eval_case(c.to_eval_case())` 与 `c` 等价 |
+| `test_benchmark_json_is_valid_evalset` | `EvalSet.from_file("agenticx/evaluation/benchmarks/reliability_v1.json")` 成功，`len(...) >= 12` |
+| `test_is_diagnosable_rejects_bare_token` | `_is_diagnosable("'_type'", tool_name="bump") is False`；`_is_diagnosable("KeyError", ...) is False` |
+| `test_is_diagnosable_accepts_full_reason` | `_is_diagnosable("bump 会产生外部副作用且执行结果未知，已跳过重跑", tool_name="bump") is True` |
+| `test_history_check_detects_orphan_tool_row` | 构造缺失对应 `assistant.tool_calls` 的 tool 行 → 一致性校验返回 False |
+| `test_history_check_detects_duplicate_tool_row` | 同一 `tool_call_id` 两条 tool 行 → False |
+| `test_history_check_accepts_valid` | 合法 messages → True |
+
+### AC-2：`tests/test_reliability_bench.py` — 端到端
+
+| 测试名 | 断言 |
+|---|---|
+| `test_bench_runs_offline` | 跑完整 `reliability_v1.json`，全程无网络（`socket.socket` monkeypatch 成抛异常也能跑完） |
+| `test_zero_duplicate_side_effects` | `metrics.duplicate_side_effect_rate == 0.0` |
+| `test_full_crash_recovery` | `metrics.crash_recovery_success_rate == 1.0` |
+| `test_full_history_consistency` | `metrics.history_consistency_rate == 1.0` |
+| `test_full_error_diagnosability` | `metrics.error_diagnosability_rate == 1.0` |
+| `test_metrics_report_contains_methodology` | `to_report()` 含「进程内模拟崩溃」字样（防止对外材料误宣传） |
+| `test_bench_is_deterministic` | 连跑 2 次，四个指标与 `per_case` 逐字段一致 |
+| `test_bench_uses_tmp_path` | 跑完后 `~/.agenticx/` 下无新增文件（全部落在 `tmp_path`） |
+
+后四条中 `test_zero_duplicate_side_effects` 与 `test_full_crash_recovery` 直接对应 master plan 的 AC-M2/AC-M3。
+
+**如果这两条跑不过，不要改测试或改基准去让它通过**——那说明 Subplan 01–03 的内核有缺陷，回到对应 Subplan 修根因。这是本 Subplan 存在的全部意义。
+
+### AC-3：不污染既有评测
+
+```bash
+pytest tests/ -k "eval" -q          # 既有评测相关测试零修改通过
+git diff --name-only agenticx/evaluation/   # 只应出现 __init__.py（追加）+ 3 个新文件
+```
+
+### AC-4：可复现命令（写进 plan，供后续引用）
+
+```bash
+python -m pytest tests/test_reliability_bench.py -q
+python -c "
+from pathlib import Path
+from agenticx.evaluation import EvalSet, ReliabilityRunner
+es = EvalSet.from_file('agenticx/evaluation/benchmarks/reliability_v1.json')
+import tempfile
+with tempfile.TemporaryDirectory() as d:
+    print(ReliabilityRunner(root=Path(d)).run(es).to_report())
+"
+```
+第二条命令的输出就是**对外可引用的可靠性数字**。Subplan 05 的决策依赖它。
+
+---
+
+## 6. no-scope-creep 边界
+
+改动文件白名单：
+
+```
+agenticx/evaluation/fault_injection.py                  (新增)
+agenticx/evaluation/reliability_runner.py               (新增)
+agenticx/evaluation/benchmarks/reliability_v1.json      (新增)
+agenticx/evaluation/__init__.py                         (仅末尾追加导出)
+tests/test_reliability_bench.py                         (新增)
+```
+
+明确禁止：
+- 不要「顺手修」`EvalRunner._execute_with_agent` 那段示意代码——它现在这样是既有状态，改它属另一件事。
+- 不要给 `EvalCase` / `EvalResult` / `EvalSummary` 加字段（用 `metadata` 承载）。
+- 不要修 `agenticx/reliability/**`。基准跑红就回上游 Subplan 修，不在这里绕过。
+- 不要为了让指标好看而放宽 4.4 的一致性四条或 4.5 的可诊断三条。
+- 不要引入 `pytest-asyncio` 之外的新测试依赖（先确认仓库已有的异步测试是怎么写的，照同一方式）。
+- 不要跑真 LLM、不要读 `~/.agenticx/config.yaml`。

--- a/.cursor/plans/2026-09-12-sdk-reliability-05-fail-closed-defaults.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-05-fail-closed-defaults.plan.md
@@ -1,0 +1,353 @@
+---
+name: sdk-reliability-05-fail-closed-defaults
+overview: 把默认姿态从 fail-open 翻到 fail-closed，并让两处"写失败被吞掉"的代码显式暴露失败。当前 agenticx/runtime/harden_flags.py:93-95 的 persist_fail_closed_enabled() 默认 False（持久化失败时带病继续），agenticx/runtime/checkpoint.py:73-88 的 CheckpointStore.save() 把写失败 logger.warning 后吞掉。这两处叠加的后果是：磁盘写不进去时用户完全无感，直到崩溃后才发现无从恢复。本 Subplan 引入统一的 reliability.posture 设置（strict | legacy），把默认切到 strict，让 CheckpointStore 的失败对调用方可见，并给出既有会话的迁移与回滚路径。必须在 Subplan 04 的基准数字证明翻转有正收益之后才动手。
+todos:
+  - id: t1
+    content: 新增 reliability_posture() 解析器（env > config.yaml > default=strict）
+    status: pending
+  - id: t2
+    content: persist_fail_closed_enabled() 默认改为跟随 posture
+    status: pending
+  - id: t3
+    content: CheckpointStore.save 失败可见（返回值 + 计数器 + 一次性告警）
+    status: pending
+  - id: t4
+    content: 用 Subplan 04 基准跑 strict/legacy 对照，落盘数字
+    status: pending
+  - id: t5
+    content: 迁移与回滚文档 + 现有测试全绿 + agx serve 冷启动冒烟
+    status: pending
+  - id: t6
+    content: 登记 Desktop GUI 后续 plan（本阶段不做前端）
+    status: pending
+isProject: false
+---
+
+# Subplan 05：fail-closed 默认姿态切换
+
+**Plan-Id**: `2026-09-12-sdk-reliability-05-fail-closed-defaults`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-05-fail-closed-defaults.plan.md`
+**Master**: `2026-09-12-sdk-reliability-kernel-master`
+**依赖**: Subplan 04 **必须先跑出基准数字**（本 plan 的 t4 是决策门槛，不是形式）
+**Planned-with**: Claude Opus 5
+**Suggested-Impl-Model**: GPT-5.x 级强推理档（理由见下）
+**Made-with**: Damon Li
+
+> **为什么这个 Subplan 不给 Grok 4.6**：它翻转的是**已上线产品**（Studio / Near 桌面端）的默认行为，影响面跨 `agent_runtime` 主循环、`checkpoint`、Desktop 用户可感知体验，且失败模式是「用户的会话被中止」——属跨栈高风险收口，需要强推理档做影响面推演。前四个 Subplan 都是新增隔离模块，风险性质完全不同。
+
+---
+
+## 1. 现状与根因
+
+### 1.1 两处 fail-open 叠加
+
+**第一处** — `agenticx/runtime/harden_flags.py:93-95`：
+
+```python
+def persist_fail_closed_enabled() -> bool:
+    """``AGX_PERSIST_FAIL_CLOSED`` / ``runtime.persist_fail_closed``. Default False."""
+    return _resolve_bool("AGX_PERSIST_FAIL_CLOSED", "runtime.persist_fail_closed", False)
+```
+
+它控制 `agenticx/runtime/agent_runtime.py:2887` 的 `_persist_or_abort()`：
+
+```2891:2899:agenticx/runtime/agent_runtime.py
+        try:
+            self._mid_turn_persist()
+        except Exception as exc:
+            logger.exception("persist before %s failed", reason)
+            from agenticx.runtime.harden_flags import persist_fail_closed_enabled
+
+            if persist_fail_closed_enabled():
+                return False, f"{type(exc).__name__}: {exc}"
+            return True, ""
+```
+
+调用点两个：`:4109`（发 LLM 请求前）与 `:6274`（执行工具前）。**默认 False 的实际含义是：磁盘写不进去（满盘/只读/权限），照样发请求、照样执行有副作用的工具。** 副作用发生了，但「我做过这件事」这条记录没落盘 —— 这正是重复副作用的产生条件。
+
+**第二处** — `agenticx/runtime/checkpoint.py:73-88`：
+
+```python
+    def save(self, checkpoint: AgentCheckpoint) -> None:
+        try:
+            ...
+        except Exception:
+            logger.warning(
+                "checkpoint save failed session=%s",
+                checkpoint.session_id,
+                exc_info=True,
+            )
+```
+
+类 docstring 自己写明：`"""Write failures are logged and swallowed (same tolerance as the existing mid-turn persist path)"""`。返回 `None`，调用方**无法区分**「存好了」和「没存上」。
+
+### 1.2 叠加后果
+
+两处都是 fail-open ⇒ 崩溃恢复能力在磁盘异常时**静默降级到零**，且：
+- 用户无任何可见信号（`logger.warning` 在 Desktop 用户眼里等于不存在）
+- 崩溃后才发现无从恢复，此时已无法补救
+- 与 `conclusions/runtime_module_conclusion.md` 里那张 `AGX_*` 表并列的其它加固项（`AGX_OVERFLOW_RETRY` 默认 True、`AGX_INTERRUPTED_CLOSERS` 默认 True、`AGX_CANCELLED_PREFIX_FINALIZE` 默认 True）姿态不一致 —— 唯独最关键的持久化保护默认关着
+
+对照上游 openai-agents-python：它在 persist 边界是 **fail-closed** 的（`_pending_session_write` / `_terminal_unrecoverable` 明确标记「已接受终态输出但尚未成功持久化」这个危险窗口，并拒绝在该窗口内继续）。这是我们目前**落后**的一点，不是领先的一点。
+
+### 1.3 但不能盲翻
+
+`persist_fail_closed_enabled()` 翻成 True 后，磁盘异常时用户会看到「本轮被中止」，比「带病继续」更刺眼。是否净收益，取决于：**中止一轮的代价** vs **重复副作用 + 无法恢复的代价**。这个判断必须有数字支撑，不能凭直觉 —— 所以 t4 是硬门槛。
+
+---
+
+## 2. In scope / Out of scope
+
+### In scope
+
+**修改：**
+- `agenticx/runtime/harden_flags.py`（新增 `reliability_posture()`；改 `persist_fail_closed_enabled()` 的默认来源）
+- `agenticx/runtime/checkpoint.py`（`save()` 改为可观测；**不改** `AgentCheckpoint` 数据结构、不改 `load()` 语义）
+- `agenticx/reliability/__init__.py`（追加导出 `reliability_posture` 的 re-export，供 SDK 侧读同一姿态）
+
+**新增：**
+- `docs/guides/reliability-posture.md`（迁移与回滚说明）
+- `tests/test_reliability_posture.py`
+- `.cursor/plans/pending/<日期>-reliability-posture-desktop-gui.plan.md`（占位后续 plan，见第 7 节）
+
+### Out of scope
+
+- **不改** `agenticx/runtime/agent_runtime.py`。`_persist_or_abort()` 的逻辑一行不动 —— 它已经正确地在 flag 为 True 时返回 `(False, detail)`，我们只改 flag 的默认值。**这一点非常重要**：`agent_runtime.py` 是 8000+ 行的主循环，本 plan 不具备改它的正当理由。
+- **不改** `agenticx/studio/server.py`（该文件的 import 区极度敏感，见工作区规则中记录的 `GroupChatRegistry` 误删事故）。
+- **不改** 其它任何 `harden_flags.py` 里的默认值。只碰 `persist_fail_closed_enabled` 一个。
+- **不改** `agenticx/reliability/**` 的 Subplan 01–03 产物（它们从一开始就是 fail-closed 的，不需要开关）。
+- **不做 Desktop / 前端改动**（见第 7 节的处理方式）。
+- 不做「持久化失败时自动降级到备用存储路径」这类补偿机制（另一个议题，容易引入新的一致性问题）。
+- 不新增第三方依赖。
+
+---
+
+## 3. t1 + t2：`reliability.posture`
+
+### 3.1 新增解析器
+
+在 `agenticx/runtime/harden_flags.py` 末尾追加（沿用文件里既有的 `_resolve_bool` / `_config_int` 风格，新增一个 `_config_str`）：
+
+```python
+RELIABILITY_POSTURES = ("strict", "legacy")
+
+
+def _config_str(key: str) -> Optional[str]:
+    try:
+        from agenticx.cli.config_manager import ConfigManager
+
+        cfg = ConfigManager.get_value(key)
+        if isinstance(cfg, str) and cfg.strip():
+            return cfg.strip().lower()
+    except Exception:
+        pass
+    return None
+
+
+def reliability_posture() -> str:
+    """``AGX_RELIABILITY_POSTURE`` / ``reliability.posture``. Default ``"strict"``.
+
+    ``strict``  — durability failures abort the current turn and surface to the
+                  user; this is the posture the reliability benchmark measures.
+    ``legacy``  — pre-2026-09 behaviour: durability failures are logged and the
+                  run continues. Kept as an explicit escape hatch, not a default.
+
+    An unrecognised value falls back to ``"strict"`` (fail-closed on config
+    typos too — a misspelled posture must not silently weaken durability).
+    """
+    raw = os.environ.get("AGX_RELIABILITY_POSTURE", "").strip().lower()
+    if raw not in RELIABILITY_POSTURES:
+        raw = _config_str("reliability.posture") or ""
+    if raw not in RELIABILITY_POSTURES:
+        return "strict"
+    return raw
+```
+
+**注意最后那条**：配错值（比如写成 `"struct"`）回落到 `strict`，不是回落到 `legacy`。理由写进 docstring：配置笔误不应该悄悄削弱持久化保证。
+
+### 3.2 改 `persist_fail_closed_enabled()`
+
+**before**（`:93-95`）：
+```python
+def persist_fail_closed_enabled() -> bool:
+    """``AGX_PERSIST_FAIL_CLOSED`` / ``runtime.persist_fail_closed``. Default False."""
+    return _resolve_bool("AGX_PERSIST_FAIL_CLOSED", "runtime.persist_fail_closed", False)
+```
+
+**after**：
+```python
+def persist_fail_closed_enabled() -> bool:
+    """``AGX_PERSIST_FAIL_CLOSED`` / ``runtime.persist_fail_closed``.
+
+    Default follows ``reliability_posture()``: True under ``strict`` (the new
+    default), False under ``legacy``. The dedicated env var / config key still
+    wins when set, so an operator can pin this single behaviour without moving
+    the whole posture.
+    """
+    return _resolve_bool(
+        "AGX_PERSIST_FAIL_CLOSED",
+        "runtime.persist_fail_closed",
+        reliability_posture() == "strict",
+    )
+```
+
+优先级链变成：`AGX_PERSIST_FAIL_CLOSED` > `runtime.persist_fail_closed` > `AGX_RELIABILITY_POSTURE` > `reliability.posture` > `strict`。
+
+**为什么保留细粒度 flag 而不是删掉**：既有测试 `tests/test_smoke_persist_fail_closed.py` 四个用例全部显式 `monkeypatch.setenv("AGX_PERSIST_FAIL_CLOSED", ...)`，保留细粒度 flag 让它们**零修改通过**。这也是运维现场最需要的能力（只关一项、不整体退回 legacy）。
+
+### 3.3 SDK 侧读同一姿态
+
+`agenticx/reliability/__init__.py` 追加：
+
+```python
+def reliability_posture() -> str:
+    """Re-export of the runtime posture resolver (see harden_flags)."""
+    from agenticx.runtime.harden_flags import reliability_posture as _impl
+
+    return _impl()
+```
+
+**必须用函数内 import**：`agenticx.reliability` 要保持零 Studio 耦合（master AC-M5），而 `harden_flags` 会 lazy-import `agenticx.cli.config_manager`。做成函数内 import 后，只有真正调用时才拉链，`import agenticx.reliability` 本身仍然干净。**AC 里要验这一点。**
+
+---
+
+## 4. t3：`CheckpointStore.save` 失败可见
+
+`agenticx/runtime/checkpoint.py` 的 `save()` 改造，三项要求：
+
+1. **返回 `bool`**（成功/失败），而不是 `None`。签名从 `def save(self, checkpoint) -> None` 改为 `-> bool`。
+2. **累计失败计数**：实例上加 `self.save_failures: int`，每次失败 +1。调用方（以及测试）可据此判断持久化是否在静默劣化。
+3. **首次失败升级日志级别**：第 1 次失败用 `logger.error`（而非现在的 `logger.warning`），后续沿用 `warning` 避免刷屏。日志文本要包含 `session_id` 与异常类型。
+
+`strict` 姿态下**是否抛异常**：**不抛**。理由：`_write_run_checkpoint()`（`agent_runtime.py:2915`）的 docstring 明确是 `"""Best-effort crash-recovery checkpoint (no-op when store absent)."""`，语义上是 best-effort 补充，不是主持久化路径（主路径是 `_mid_turn_persist`，由 `_persist_or_abort` 守着）。在这里抛异常会让 checkpoint 从「加分项」变成「新的失败源」，风险大于收益。
+
+**改动后 docstring 必须更新**：现在写的 `"""Write failures are logged and swallowed..."""` 已不准确，改成说明返回值与计数器语义。
+
+**调用方是否要改**：`_write_run_checkpoint` 目前忽略返回值。**本 plan 不改它**（那是 `agent_runtime.py`，out of scope）。返回值先给测试和未来的 Desktop 指示灯用。这个「暂时无人消费返回值」的状态要在 plan 里写明，不要让实施者以为漏了接线。
+
+---
+
+## 5. t4：对照基准（决策门槛）
+
+用 Subplan 04 的 `ReliabilityRunner` 跑两遍：
+
+```bash
+AGX_RELIABILITY_POSTURE=legacy python -c "<Subplan 04 AC-4 的报告脚本>" > /tmp/posture-legacy.md
+AGX_RELIABILITY_POSTURE=strict python -c "<同一脚本>" > /tmp/posture-strict.md
+diff /tmp/posture-legacy.md /tmp/posture-strict.md
+```
+
+把两份四指标数字**原样**抄进 `docs/guides/reliability-posture.md` 的对照表。
+
+**放行条件（全部满足才继续 t1–t3 的落地）**：
+
+| 条件 | 判据 |
+|---|---|
+| strict 的 `duplicate_side_effect_rate` ≤ legacy 的 | 不能变差 |
+| strict 的 `crash_recovery_success_rate` ≥ legacy 的 | 不能变差 |
+| strict 的 `history_consistency_rate` == 1.0 | 硬要求 |
+| strict 的 `error_diagnosability_rate` ≥ legacy 的 | 中止一轮必须比带病继续更可诊断 |
+
+**如果 strict 在任一指标上更差**：不要翻默认值。把数字写进 `docs/guides/reliability-posture.md`，把本 Subplan 的 t1–t3 缩减为「只加 `reliability.posture` 开关、默认仍 legacy」，并在文档里写明为什么没翻。诚实记录一个负结果，比硬翻一个没有证据支撑的默认值有价值 —— 这也是 master plan §5「AC-M2 数字出来之前不对外声称领先」的同一条纪律。
+
+---
+
+## 6. 验收标准
+
+### AC-1：既有测试零修改通过（最硬）
+
+```bash
+pytest tests/test_smoke_persist_fail_closed.py -q
+pytest tests/ -k "harden or checkpoint or persist" -q
+```
+
+`tests/test_smoke_persist_fail_closed.py` 的 4 个用例都显式设了 env var，**必须一行不改就绿**。若需要改测试，说明第 3.2 节的优先级链实现错了。
+
+### AC-2：`tests/test_reliability_posture.py`
+
+| 测试名 | 断言 |
+|---|---|
+| `test_default_posture_is_strict` | 清空相关 env → `reliability_posture() == "strict"` |
+| `test_env_selects_legacy` | `AGX_RELIABILITY_POSTURE=legacy` → `"legacy"` |
+| `test_env_case_insensitive` | `AGX_RELIABILITY_POSTURE=STRICT` → `"strict"` |
+| `test_typo_falls_back_to_strict` | `AGX_RELIABILITY_POSTURE=struct` → `"strict"`（**不是** legacy） |
+| `test_persist_default_follows_posture` | posture=strict + 无 `AGX_PERSIST_FAIL_CLOSED` → `persist_fail_closed_enabled() is True`；posture=legacy → `False` |
+| `test_explicit_flag_overrides_posture` | posture=strict + `AGX_PERSIST_FAIL_CLOSED=0` → `False`；posture=legacy + `AGX_PERSIST_FAIL_CLOSED=1` → `True` |
+| `test_other_flags_unchanged` | `overflow_retry_enabled()` / `interrupted_closers_enabled()` / `cancelled_prefix_finalize_enabled()` / `fresh_round_loop_enabled()` / `max_overflow_retries()` 在两种 posture 下取值**完全一致**（证明没误伤别的开关） |
+| `test_checkpoint_save_returns_true_on_success` | 正常路径返回 `True`，`save_failures == 0` |
+| `test_checkpoint_save_returns_false_on_failure` | monkeypatch 存储抛异常 → 返回 `False`，`save_failures == 1`，**不抛异常** |
+| `test_checkpoint_first_failure_logs_error` | `caplog` 里第 1 次是 `ERROR` 级、第 2 次是 `WARNING` 级；两条都含 `session_id` |
+| `test_reliability_import_stays_clean` | `import agenticx.reliability` 后 `sys.modules` 里无 `agenticx.studio.*`（验证 3.3 的函数内 import） |
+
+### AC-3：Studio 冷启动冒烟（强制门槛）
+
+改了 `harden_flags.py` / `checkpoint.py` 就必须验后端起得来：
+
+```bash
+agx serve --host 127.0.0.1 --port 18801 &
+sleep 12
+curl --noproxy '*' -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18801/api/session
+curl --noproxy '*' -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18801/api/avatars
+curl --noproxy '*' -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18801/api/sessions
+kill %1
+```
+
+三个都必须 200。`--noproxy '*'` 不能省（本机 shell 常配了 `all_proxy`，走 SOCKS 会拿到空响应）。
+
+### AC-4：真实会话不被打断（人工验证一次）
+
+启动 Desktop（`npm run dev`，Vite 端口 5713），与 Machi 正常对话 3 轮含至少 1 次工具调用，确认：
+- 一切正常时**没有任何**新增的报错/提示（strict 姿态在磁盘健康时应完全不可感知）
+- 历史会话、分身列表、工作区都正常（对齐工作区规则里那条排障经验：这三处同时空态优先怀疑 `agx serve` 没活）
+
+把观察结果写进 `docs/guides/reliability-posture.md` 的验证记录段。
+
+### AC-5：文档
+
+`docs/guides/reliability-posture.md` 必须含：
+1. 两种 posture 的行为差异表
+2. t4 的 strict/legacy 四指标对照（**真实跑出来的数字，不许编**）
+3. 回滚方法：`export AGX_RELIABILITY_POSTURE=legacy` 或在 `~/.agenticx/config.yaml` 写 `reliability: {posture: legacy}`
+4. 只回滚单项：`export AGX_PERSIST_FAIL_CLOSED=0`
+5. 第 5 节的方法论限制说明（进程内模拟崩溃，非物理故障演练）
+6. AC-4 的人工验证记录
+
+---
+
+## 7. t6：Desktop GUI 后续登记
+
+工作区规则要求「用户可改配置项必须提供 Desktop 设置面板 GUI」。本 Subplan 引入的 `reliability.posture` 是用户可改配置，但第一阶段范围**明确排除前端改动**（master plan §3）。
+
+处理方式：**不在这里做，但必须显式登记**，不能默默留一个只能手改 YAML 的开关。
+
+新建 `.cursor/plans/pending/<实施当日日期>-reliability-posture-desktop-gui.plan.md`，内容至少写清：
+- 落点：`desktop/src/components/SettingsPanel.tsx` 的 Automation / Runtime 分区（那里已有 `max_tool_rounds` / `max_taskspaces` 等运行参数字段，`saveRuntimeConfig` / `loadRuntimeConfig` 这对 IPC 已存在，只需在参数包里加一个键）
+- 需同步的四处：`desktop/electron/main.ts` 的 IPC handler、`desktop/electron/preload.ts`、`desktop/src/global.d.ts`、`SettingsPanel.tsx` 的表单字段
+- 控件形态：两态选择（严格 / 兼容），不是 `SettingsSwitch`——姿态不是布尔开关，未来可能加第三态
+- 提醒：改 `desktop/electron/main.ts` 后必须**完整重启** `npm run dev`（`tsc --watch` 会重编 `dist-electron/`，但主进程不热重载，只刷渲染进程看不到新 IPC）
+
+本 Subplan 的验收只要求这个 plan 文件**存在且落点具体**，不要求实现。
+
+---
+
+## 8. no-scope-creep 边界
+
+改动文件白名单：
+
+```
+agenticx/runtime/harden_flags.py                          (新增 2 个函数 + 改 1 个函数的默认来源)
+agenticx/runtime/checkpoint.py                            (仅 save() 返回值/计数器/日志级别 + docstring)
+agenticx/reliability/__init__.py                          (仅追加 reliability_posture re-export)
+docs/guides/reliability-posture.md                        (新增)
+tests/test_reliability_posture.py                         (新增)
+.cursor/plans/pending/<date>-reliability-posture-desktop-gui.plan.md   (新增，仅登记)
+```
+
+明确禁止：
+- **不改 `agenticx/runtime/agent_runtime.py`**，一行都不改。`_persist_or_abort` 的逻辑已经对了。
+- **不改 `agenticx/studio/server.py`**，一行都不改。
+- 不翻 `harden_flags.py` 里其它任何默认值（`fresh_round_loop` 默认 False 是有原因的，别顺手动）。
+- 不改 `AgentCheckpoint` 数据结构、不改 `CheckpointStore.load()` 的「缺失/损坏读作 None」语义。
+- 不给 `CheckpointStore.save` 加「失败时抛异常」（第 4 节已说明理由）。
+- 不做前端改动。
+- 不在 t4 数字不达标时硬翻默认值。

--- a/.cursor/plans/2026-09-12-sdk-reliability-kernel-master.plan.md
+++ b/.cursor/plans/2026-09-12-sdk-reliability-kernel-master.plan.md
@@ -1,0 +1,207 @@
+---
+name: sdk-reliability-kernel-master
+overview: 第一阶段目标是「AgenticX SDK 在可靠性基准上领先」。当前 AgenticX 的崩溃韧性能力全部囚禁在 Studio 的 AgentRuntime 里，可嵌入的 ReActAgent SDK 原语（agenticx/agents/react_agent_async.py，402 行）没有任何持久化、续跑、工具调用身份或重放保护；而 interrupted_closers 只能告诉模型「结果未知，自己去核验」，这是概率性保证。本 master plan 新建 agenticx/reliability/ 可靠性内核（调用身份 + 幂等账本 + RunState + 重放安全策略），以双适配层分别接入 SDK 侧 ReActAgent 与产品侧 AgentRuntime，并扩展既有 agenticx/evaluation/ 增加故障注入基准，让「更可靠」成为可复现的数字而不是形容词。共 5 个 Subplan。
+todos:
+  - id: s1
+    content: Subplan 01 — Tool-call 规范身份与幂等账本（agenticx/reliability/）
+    status: pending
+  - id: s2
+    content: Subplan 02 — SDK 侧 RunState 持久化与续跑（ReActAgent 接入）
+    status: pending
+  - id: s3
+    content: Subplan 03 — Replay 安全策略（分层否决 + 工具自声明）
+    status: pending
+  - id: s4
+    content: Subplan 04 — 故障注入可靠性基准（扩展 agenticx/evaluation/）
+    status: pending
+  - id: s5
+    content: Subplan 05 — fail-closed 默认姿态切换（依赖 S4 的数字）
+    status: pending
+isProject: true
+---
+
+# 第一阶段：AgenticX SDK 可靠性内核
+
+**Plan-Id**: `2026-09-12-sdk-reliability-kernel-master`
+**Plan-File**: `.cursor/plans/2026-09-12-sdk-reliability-kernel-master.plan.md`
+**Owner**: Damon Li
+**Planned-with**: Claude Opus 5
+**Made-with**: Damon Li
+
+---
+
+## 0. 一句话目标
+
+让「AgenticX SDK 比 openai-agents-python 更可靠」变成**可复现的四个数字**：重复副作用率、崩溃恢复成功率、历史一致率、错误可诊断率。
+
+不是「我们也有 checkpoint」，而是「同一套故障注入矩阵下，我们的重复副作用率是 0、他们不是」。
+
+---
+
+## 1. 为什么是这件事（证据链，执行者必读）
+
+本节的事实全部来自对本仓库与上游 `openai/openai-agents-python@fbd2dbc` 的源码核对，执行时不需要回看任何对话记录。
+
+### 1.1 上游的可靠性机制在 SDK 一等公民层
+
+| 上游机制 | 位置 | 语义 |
+|---|---|---|
+| `RunState` | `src/agents/run_state.py` | 可序列化的 run 快照，HITL / 崩溃后从中间态恢复，**是 SDK 公开 API** |
+| 工具调用身份 | `call_id` + payload fingerprint | 完全相同的调用可跳过重放；**同 id 但参数变了直接抛 `ModelBehaviorError`** |
+| 分层重放否决 | `replay_safety` / `response_started` / `stateful_request` / `_hard_veto` | 普通 `retry=True` 永远不能绕过重放保护；`approve_unsafe_replay` 对流式请求无效 |
+| 持久化边界 | `_pending_session_write` / `_terminal_unrecoverable` | 明确标注「已接受终态输出但尚未落盘」的危险窗口 |
+
+### 1.2 AgenticX 的实际状况（已逐一核对）
+
+**（a）硬化能力全在 Studio，SDK 原语裸奔。**
+
+`agenticx/runtime/agent_runtime.py` 有一整套长运行硬化：`_persist_or_abort()`（:2887）、崩溃恢复的 `interrupted_closers`、`compaction_journal` 孤儿锁、`provider_fallback` 兜底否决、上下文溢出重试。
+
+但可嵌入的 SDK 原语 `agenticx/agents/react_agent_async.py::ReActAgent` **一行持久化都没有**。用 `rg 'checkpoint|persist|resume'` 扫这个文件，零命中。它的 `astream()`（:220-341）是纯内存循环：`messages` 是局部变量，进程一死全部消失；`except asyncio.CancelledError` 分支（:339-341）只 yield 一个 `ErrorEvent` 就 `raise`，**已经跑完的工具结果连带 messages 一起丢弃**，调用方拿不到任何可续跑的东西。
+
+`agenticx/runtime/checkpoint.py::CheckpointStore` 无法复用：它 `from agenticx.studio.storage.factory import get_sync_storage`（:32-33），是 Studio 专属的，把它塞进 SDK 会让 `agenticx.agents` 反向依赖 `agenticx.studio`，破坏 `ReActAgent`「零 Studio 耦合」的既有契约（见 `conclusions/agents_module_conclusion.md`）。
+
+**（b）没有任何工具调用身份概念。**
+
+全仓 `rg 'fingerprint'` 的命中全是别的东西：`prompt_cache_policy` 的前缀缓存指纹、`kb/ingest_cache` 的入库指纹、`LoopDetector.fingerprint_from_result` 的循环检测结果指纹。**没有一个是「这次工具调用是不是上次那一次」**。
+
+后果直接体现在 `agenticx/runtime/interrupted_closers.py:18-22`：崩溃恢复时对已派发但结果未知的调用，只能塞一句自然语言：
+
+```
+"[中断] 该工具调用已经发出，但运行时在拿到结果前中断，执行结果未知。
+禁止直接重试写入类操作；先用只读方式核验外部状态…"
+```
+
+这是把幂等判断**外包给 LLM 的自觉性**。上游是查账本得到确定答案。这就是第一阶段要补的核心差距。
+
+**（c）默认姿态是 fail-open。**
+
+- `agenticx/runtime/harden_flags.py:93-95`：`persist_fail_closed_enabled()` 默认 **False**，即持久化失败默认「带病继续」。
+- `agenticx/runtime/checkpoint.py:73-88`：`CheckpointStore.save()` 把写失败 `logger.warning` 后吞掉，类 docstring 自己写明 "Write failures are logged and swallowed"。
+
+也就是说：checkpoint 写不进去，运行照常往下跑，崩溃后无从恢复，且**没人知道**。上游在这个位置是 fail-closed。
+
+**（d）评测框架有，但不测可靠性。**
+
+`agenticx/evaluation/` 已经很完整：`EvalSet` / `EvalCase`、`TrajectoryMatcher`（EXACT/PARTIAL/UNORDERED）、`EvalRunner`（`runner.py:24`）、`LLMJudge`、`SpanEvaluator`、`TraceToEvalSetConverter`。
+
+但它们全部衡量**正确性**（工具调用序列对不对、输出好不好），没有任何**故障下的行为**：没有故障注入、没有重复副作用计数、没有恢复成功率。所以本阶段的基准必须**扩展** `agenticx/evaluation/`，绝不另起一套评测框架。
+
+**（e）已有的幂等是 HTTP 层，不是工具层。**
+
+`.cursor/plans/2026-06-06-session-identity-single-chokepoint-and-idempotency.plan.md` 已落地 `/api/chat` 的 `client_turn_id` 幂等键，解决「同一个 POST 重复落盘」。那是请求级，与本阶段的工具调用级正交，**不要复用、不要改动它**。
+
+**（f）副作用分级已经存在，但被 Studio 依赖锁在门内。**
+
+`agenticx/runtime/replay_ledger/`（2723 行，来自 `2026-09-10-long-run-replay-branching-master`）里已有 `contracts.py:17` 的 `EFFECT_CLASSES = {none, read, local_write, external_write, unknown}` 与 `effects.py:65` 的 `classify_tool_effect()`——内置工具白名单齐全、`bash_exec` 走 `assess_command()` 深度判定、未知一律 `"unknown"`（已经是 fail-closed 姿态）。**S3 必须复用它，不许另造分类法。**
+
+但实测 `from agenticx.runtime.replay_ledger.effects import classify_tool_effect` 会拉进 5 个 `agenticx.studio.*` 模块：包 `__init__.py:17` eager import `store.py`，而 `store.py:42` `from agenticx.studio.storage.factory import _default_sessions_root`。所以 S3 的第一步是把那一处导出惰性化（对照：`agenticx.runtime.interrupted_closers` 实测 0 个 Studio 模块，可以放心引用）。
+
+另外要区分清楚：`replay_ledger` 的 `branchable` / `unbranchable_reason` 解决的是「能不能从这个历史事件**主动分叉**」，与本阶段的「崩溃后这个已派发的工具**能不能重跑**」是两个不同判断，**不要强行统一**。
+
+### 1.3 路线选择：可靠性内核 + 双适配层
+
+三条候选路线：
+
+1. 只在 Studio `AgentRuntime` 上继续打补丁 —— 否决：第一阶段的目标是 **SDK** 领先，补 Studio 不改变 SDK 裸奔的事实。
+2. 把 `ReActAgent` 和 `AgentRuntime` 合并成统一 Runner —— 否决：`AgentRuntime` 是产品主路径，重写它属于高回归风险，且违反 no-scope-creep。
+3. **新建 `agenticx/reliability/` 内核，定义调用身份、事务性检查点、续跑协议、失败语义；再以两个薄适配层分别接入 `ReActAgent`（SDK 侧，本阶段的基准对象）与 `AgentRuntime`（产品侧，S3/S5 阶段接入）** —— **采用**。
+
+第 3 条的好处：SDK 侧先拿到可对外发布的基准数字，产品侧后续复用同一内核而不必重写既有循环。
+
+---
+
+## 2. 交付项（5 个 Subplan）
+
+| # | Subplan | 交付物 | 依赖 |
+|---|---|---|---|
+| 01 | Tool-call 规范身份与幂等账本 | `agenticx/reliability/call_identity.py`、`call_ledger.py` | 无 |
+| 02 | SDK 侧 RunState 持久化与续跑 | `agenticx/reliability/run_state.py` + `ReActAgent` 接入 | 01 |
+| 03 | Replay 安全策略（分层否决） | `agenticx/reliability/replay_policy.py` + `BaseTool.effect_class`（复用已有 5 值 `EFFECT_CLASSES`，不另造 `replay_safety` 三值） | 01 |
+| 04 | 故障注入可靠性基准 | `agenticx/evaluation/fault_injection.py`、`reliability_runner.py` | 01、02、03 |
+| 05 | fail-closed 默认姿态切换 | `reliability.posture` 设置 + 默认翻转 | 04（要用它的数字证明翻转有收益） |
+
+### 2.1 推荐实施模型
+
+| Subplan | Suggested-Impl-Model | 理由 |
+|---|---|---|
+| 01 | Grok 4.6 | 纯算法 + 文件存储，边界条件多但无跨栈风险，中档代码模型足够 |
+| 02 | Grok 4.6 | 单文件接入（`react_agent_async.py` 402 行），改动面清晰 |
+| 03 | Grok 4.6 | 策略表 + 工具基类属性，样板性质 |
+| 04 | Grok 4.6 | 扩展既有 evaluation，测试代码量大但模式重复 |
+| 05 | GPT-5.x 级强推理档 | **默认行为翻转**，影响 Studio/Near 全部存量会话，属跨栈高回归收口 |
+
+推荐仅为建议，最终 `Impl-Model` trailer 以实际使用为准。
+
+### 2.2 执行顺序
+
+```mermaid
+graph LR
+    S1[01 调用身份与账本] --> S2[02 SDK RunState]
+    S1 --> S3[03 重放安全策略]
+    S2 --> S4[04 故障注入基准]
+    S3 --> S4
+    S4 --> S5[05 fail-closed 默认]
+```
+
+01 必须先完成（02/03 都依赖 `CallLedger`）。02 与 03 可并行。04 需要 02、03 都在。05 最后，且必须先有 04 的基线数字。
+
+---
+
+## 3. 全局 In scope / Out of scope
+
+### In scope
+
+- 新建 `agenticx/reliability/` 包（本阶段唯一的新增顶层子模块）。
+- 修改 `agenticx/agents/react_agent_async.py`（SDK 原语接入内核）。
+- 修改 `agenticx/tools/base.py`（新增 `effect_class` 类属性与 `resolve_effect_class()`，仅加不改）。
+- S3 中把 `agenticx/runtime/replay_ledger/__init__.py` 的 `ReplayLedgerStore` 改为惰性导出（约 8 行，沿用 `agenticx/runtime/__init__.py` 已有的 `__getattr__` 模式），使 SDK 层能复用既有的 `classify_tool_effect` 而不被 Studio 依赖污染。
+- 扩展 `agenticx/evaluation/`（新增 2 个文件，不改既有文件的行为）。
+- S5 中修改 `agenticx/runtime/harden_flags.py` 与 `agenticx/runtime/checkpoint.py` 的默认值/失败语义。
+- 新增 `tests/test_reliability_*.py` 系列。
+
+### Out of scope（严禁触碰）
+
+- **不得重写 `agenticx/runtime/agent_runtime.py` 的主循环。** S3/S5 只允许在既有钩子点做最小接线，`_run_turn_inner` 的 `for round_idx in range(...)` 结构不动。
+- **不得改动 `agenticx/studio/server.py`。** 该文件的 import 区块极度敏感（历史事故：一次无关修复误删 `from agenticx.avatar.group_chat import GroupChatRegistry` 导致 `agx serve` 冷启动即崩）。本阶段没有任何理由改它。
+- **不做分布式 CAS / 跨主机一致性。** 账本是单机 per-session 的。上游也没有分布式 CAS。
+- **不重复 `.cursor/plans/pending/2026-09-10-long-run-replay-branching-master.plan.md`** 的 Run Ledger / 内容寻址检查点 / 分支血缘。那个 plan 解决「回放与分支」（用户能回看和从中间分叉），本 plan 解决「崩溃后不重复副作用」。两者的账本用途不同：那边是 append-only 事件投影，这边是调用身份查重表。**如果两个 plan 都实施，S1 的 `CallLedger` 可被那个 plan 的 `RunEvent` 流消费，但不合并、不互相依赖。**
+- **不重复 `.cursor/plans/pending/2026-09-09-near-personal-agent-control-plane-master.plan.md`** 的 personal-eval / observation-ledger。
+- **不动 `/api/chat` 的 `client_turn_id` 幂等**（请求级，正交）。
+- **不改 `interrupted_closers.py` 的现有文案与纯函数签名**，只在 S2 中让调用方在有账本时优先走账本结论（S2 会写明具体接线方式）。
+- 不做前端 / Desktop 改动。本阶段是纯 Python 底层能力。
+
+---
+
+## 4. 阶段验收标准（AC）
+
+第一阶段整体完成的判据（每条都可执行）：
+
+- **AC-M1**：`pytest tests/test_reliability_call_identity.py tests/test_reliability_ledger.py tests/test_reliability_run_state.py tests/test_reliability_replay_policy.py tests/test_reliability_bench.py -q` 全绿。
+- **AC-M2**：`python -m agenticx.evaluation.reliability_runner --suite builtin --report /tmp/agx-reliability.json` 产出含四项指标的 JSON；在 `posture=strict` 下 **duplicate_side_effect_rate == 0.0**。
+- **AC-M3**：`ReActAgent` 在 `kill_after_tool_result_before_persist` 故障下续跑，副作用计数器工具的最终计数等于故障前已完成的调用数（不多不少）。
+- **AC-M4**：同一 `call_id` 携带不同参数二次出现时抛 `ToolCallIdentityError`，且异常消息包含 `call_id`、两次的 canonical key 前 16 位、以及冲突的字段名。
+- **AC-M5**：`python -c "import agenticx.agents"` 不引入 `agenticx.studio`（保持 SDK 零产品耦合）。验证命令：
+  ```bash
+  python -c "import sys, agenticx.agents; assert not [m for m in sys.modules if m.startswith('agenticx.studio')], [m for m in sys.modules if m.startswith('agenticx.studio')]"
+  ```
+- **AC-M6**：`agx serve --host 127.0.0.1 --port 18799` 冷启动成功且 `/api/session`、`/api/avatars`、`/api/sessions` 返回 200（因为 S3/S5 会碰 runtime 层，这条是硬门槛）。
+
+---
+
+## 5. 对外叙事（S4 完成后才能说）
+
+在拿到 AC-M2 的数字之前，**不要**在 README / 官网 / issue 里声称「比 openai-agents-python 更可靠」。
+拿到之后，可发布的表述是：「在公开的故障注入矩阵下，AgenticX SDK 的重复副作用率为 0，恢复成功率 X%」，并附上基准脚本让人复现。
+
+上游合作轨（给 openai-agents-python 提 PR）不在第一阶段，本 plan 不涉及。
+
+---
+
+## 6. 各 Subplan 文件
+
+- `.cursor/plans/pending/2026-09-12-sdk-reliability-01-call-identity.plan.md`
+- `.cursor/plans/pending/2026-09-12-sdk-reliability-02-sdk-durability.plan.md`
+- `.cursor/plans/pending/2026-09-12-sdk-reliability-03-replay-safety.plan.md`
+- `.cursor/plans/pending/2026-09-12-sdk-reliability-04-fault-injection-bench.plan.md`
+- `.cursor/plans/pending/2026-09-12-sdk-reliability-05-fail-closed-defaults.plan.md`

--- a/.cursor/plans/pending/2026-09-12-reliability-posture-desktop-gui.plan.md
+++ b/.cursor/plans/pending/2026-09-12-reliability-posture-desktop-gui.plan.md
@@ -1,0 +1,23 @@
+# reliability.posture Desktop GUI
+
+**Plan-Id**: `2026-09-12-reliability-posture-desktop-gui`
+**Plan-File**: `.cursor/plans/pending/2026-09-12-reliability-posture-desktop-gui.plan.md`
+**Planned-with**: Grok 4.6
+**Suggested-Impl-Model**: Composer 2.5
+**Made-with**: Damon Li
+
+第一阶段只引入了 `reliability.posture`（`strict` / `legacy`）的 env / YAML 开关。工作区规则要求用户可改配置必须有 Desktop 设置面板，本 plan 只登记落点，不在本阶段实现。
+
+## 落点
+
+- `desktop/src/components/SettingsPanel.tsx` 的 Automation / Runtime 分区（已有 `max_tool_rounds` / `max_taskspaces`，走 `saveRuntimeConfig` / `loadRuntimeConfig`）。在参数包里加一个 `reliability_posture` 键。
+- 同步四处：
+  - `desktop/electron/main.ts` 的 IPC handler（读/写 `~/.agenticx/config.yaml` 的 `reliability.posture`）
+  - `desktop/electron/preload.ts`
+  - `desktop/src/global.d.ts`
+  - `SettingsPanel.tsx` 表单字段
+- 控件：两态选择（严格 / 兼容），不要做成 `SettingsSwitch`。姿态不是布尔开关，后续可能加第三态。
+
+## 提醒
+
+改 `desktop/electron/main.ts` 后必须完整重启 `npm run dev`。`tsc --watch` 会重编 `dist-electron/`，主进程不热重载，只刷渲染进程看不到新 IPC。

--- a/agenticx/agents/agent_events.py
+++ b/agenticx/agents/agent_events.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Typed events for the canonical async FC ReAct agent stream.
 
-Minimal event union (<=6 kinds) for FastAPI SSE, observability, and arun/astream
+Typed event union (7 kinds) for FastAPI SSE, observability, and arun/astream
 consistency. Consumed by ``react_agent_async.ReActAgent.astream``.
 
 Author: Damon Li
@@ -19,6 +19,7 @@ EventType = Literal[
     "tool_result",
     "final",
     "error",
+    "interrupted",
 ]
 
 
@@ -79,6 +80,17 @@ class ErrorEvent:
     recoverable: bool = False
 
 
+@dataclass
+class InterruptedEvent:
+    """Run stopped before producing a final output; carries resumable state."""
+
+    type: Literal["interrupted"] = "interrupted"
+    reason: Literal["user_stop", "cancelled"] = "user_stop"
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    iteration: int = 0
+    run_id: str = ""
+
+
 AgentEvent = Union[
     TokenEvent,
     ReasoningEvent,
@@ -86,4 +98,5 @@ AgentEvent = Union[
     ToolResultEvent,
     FinalEvent,
     ErrorEvent,
+    InterruptedEvent,
 ]

--- a/agenticx/agents/react_agent_async.py
+++ b/agenticx/agents/react_agent_async.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, List, Optional, Sequence
@@ -30,6 +31,7 @@ from agenticx.agents.agent_events import (
     AgentEvent,
     ErrorEvent,
     FinalEvent,
+    InterruptedEvent,
     ReasoningEvent,
     ToolCallEvent,
     ToolResultEvent,
@@ -38,6 +40,19 @@ from agenticx.core.agent_executor import ToolRegistry
 from agenticx.core.offload.protocol import Offloader, should_offload
 from agenticx.llms.base import BaseLLMProvider
 from agenticx.llms.response import LLMResponse
+from agenticx.reliability.call_identity import (
+    canonical_call_key,
+    diff_canonical_fields,
+    stable_call_id,
+)
+from agenticx.reliability.call_ledger import CallLedger, Verdict
+from agenticx.reliability.errors import ToolCallIdentityError
+from agenticx.reliability.replay_policy import ReplayRequest, decide_replay
+from agenticx.reliability.run_state import PendingCall, RunState, RunStateStore
+from agenticx.runtime.interrupted_closers import (
+    KIND_OUTCOME_UNKNOWN,
+    OUTCOME_UNKNOWN_CONTENT,
+)
 from agenticx.runtime.loop_detector import LoopDetector
 from agenticx.tools.base import BaseTool
 
@@ -96,6 +111,9 @@ class ReActAgent:
         loop_detector: LoopDetector | None = None,
         session_id: str | None = None,
         model_name: str = "",
+        run_store: RunStateStore | None = None,
+        call_ledger: CallLedger | None = None,
+        run_id: str | None = None,
     ) -> None:
         self.llm = llm
         self.system_prompt = system_prompt
@@ -106,6 +124,11 @@ class ReActAgent:
         self.loop_detector = loop_detector or LoopDetector()
         self.session_id = session_id or str(uuid.uuid4())
         self.model_name = model_name or getattr(llm, "model", "")
+        self._run_store = run_store
+        self._ledger = call_ledger
+        self._run_id = run_id or str(uuid.uuid4())
+        self._current_query = ""
+        self._state_created_at = 0.0
 
         self._registry = ToolRegistry()
         self._tools: List[BaseTool] = []
@@ -217,104 +240,315 @@ class ReActAgent:
             msg["tool_calls"] = response.tool_calls
         return msg
 
-    async def astream(
+    def _normalize_tool_call(
         self,
-        query: str,
+        tc: Dict[str, Any],
         *,
-        history: Optional[List[Dict[str, Any]]] = None,
-    ) -> AsyncIterator[AgentEvent]:
-        """Run the FC loop, yielding typed events (NFR-4 source of truth)."""
-        self._stop_requested = False
-        messages = self._build_messages(query, history)
-        iterations = 0
+        iteration: int,
+        position: int,
+    ) -> tuple[str, str, Dict[str, Any]]:
+        """Return (stable_call_id, tool_name, arguments) for one provider tool_call."""
+        fn = tc.get("function") or {}
+        name = str(fn.get("name", "") or "")
+        args = _parse_tool_arguments(fn.get("arguments"))
+        call_id = stable_call_id(
+            tc.get("id"),
+            tool_name=name,
+            iteration=iteration,
+            position=position,
+        )
+        return call_id, name, args
 
-        try:
-            while iterations < self.max_iterations:
-                if self._stop_requested:
-                    yield ErrorEvent(
-                        message="run stopped by user",
-                        recoverable=False,
+    def _save_state(
+        self,
+        *,
+        phase: str,
+        messages: List[Dict[str, Any]],
+        iteration: int,
+        pending_calls: Sequence[PendingCall] = (),
+    ) -> None:
+        if self._run_store is None:
+            return
+        now = time.time()
+        if not self._state_created_at:
+            self._state_created_at = now
+        self._run_store.save(
+            RunState(
+                run_id=self._run_id,
+                session_id=self.session_id,
+                query=self._current_query,
+                messages=list(messages),
+                iteration=iteration,
+                phase=phase,  # type: ignore[arg-type]
+                pending_calls=list(pending_calls),
+                created_at=self._state_created_at,
+                updated_at=now,
+            )
+        )
+
+    def _finish_final(
+        self,
+        messages: List[Dict[str, Any]],
+        iterations: int,
+        output: Any,
+        *,
+        success: bool,
+    ) -> FinalEvent:
+        self._save_state(phase="completed", messages=messages, iteration=iterations)
+        if self._run_store is not None:
+            self._run_store.clear()
+        return FinalEvent(
+            output=output,
+            success=success,
+            messages=list(messages),
+            iterations=iterations,
+        )
+
+    def _interrupted_event(
+        self,
+        reason: str,
+        messages: List[Dict[str, Any]],
+        iteration: int,
+    ) -> InterruptedEvent:
+        self._save_state(
+            phase="interrupted",
+            messages=messages,
+            iteration=iteration,
+        )
+        return InterruptedEvent(
+            reason=reason,  # type: ignore[arg-type]
+            messages=list(messages),
+            iteration=iteration,
+            run_id=self._run_id,
+        )
+
+    def _rewrite_assistant_tool_ids(
+        self,
+        messages: List[Dict[str, Any]],
+        normalized: List[tuple[str, str, Dict[str, Any]]],
+    ) -> None:
+        if not messages:
+            return
+        last = messages[-1]
+        raw_calls = last.get("tool_calls") or []
+        if last.get("role") != "assistant" or not raw_calls:
+            return
+        rewritten: List[Dict[str, Any]] = []
+        for tc, (call_id, _name, _args) in zip(raw_calls, normalized):
+            item = dict(tc)
+            item["id"] = call_id
+            rewritten.append(item)
+        last["tool_calls"] = rewritten
+
+    def _enforce_call_identity(
+        self,
+        normalized: List[tuple[str, str, Dict[str, Any]]],
+    ) -> List[tuple[str, str, Dict[str, Any]]]:
+        """Drop same-id same-args duplicates; reject same-id changed args."""
+        unique: List[tuple[str, str, Dict[str, Any]]] = []
+        seen: dict[str, tuple[str, Dict[str, Any]]] = {}
+        for call_id, name, args in normalized:
+            key = canonical_call_key(name, args)
+            if call_id in seen:
+                prev_key, prev_args = seen[call_id]
+                if prev_key != key:
+                    raise ToolCallIdentityError(
+                        call_id,
+                        recorded_key=prev_key,
+                        incoming_key=key,
+                        changed_fields=diff_canonical_fields(prev_args, args),
                     )
-                    break
+                continue
+            seen[call_id] = (key, args)
+            if self._ledger is not None:
+                reconciliation = self._ledger.reconcile_safe(call_id, name, args)
+                if reconciliation.verdict is Verdict.IDENTITY_CONFLICT:
+                    record = reconciliation.record
+                    raise ToolCallIdentityError(
+                        call_id,
+                        recorded_key=record.canonical_key if record else "",
+                        incoming_key=key,
+                        changed_fields=(
+                            diff_canonical_fields(record.arguments, args)
+                            if record is not None
+                            else ()
+                        ),
+                    )
+            unique.append((call_id, name, args))
+        return unique
 
-                iterations += 1
+    async def _append_tool_outcome(
+        self,
+        messages: List[Dict[str, Any]],
+        call_id: str,
+        name: str,
+        args: Dict[str, Any],
+        content: str,
+        *,
+        success: bool,
+        metadata: Dict[str, Any] | None = None,
+        persist_ledger: bool = True,
+    ) -> ToolResultEvent:
+        self.loop_detector.record_call(
+            name,
+            LoopDetector.args_signature(args),
+            has_progress=success,
+            result_fingerprint=LoopDetector.fingerprint_from_result(content),
+        )
+        row: Dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": call_id,
+            "content": content,
+        }
+        if metadata:
+            row["metadata"] = metadata
+        messages.append(row)
+        if persist_ledger and self._ledger is not None:
+            if success:
+                self._ledger.record_result(call_id, content)
+            else:
+                self._ledger.record_failure(call_id, content)
+        return ToolResultEvent(
+            tool_call_id=call_id,
+            tool_name=name,
+            content=content,
+            success=success,
+        )
+
+    async def _loop(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        start_iteration: int,
+        increment_first: bool = True,
+    ) -> AsyncIterator[AgentEvent]:
+        """Shared FC loop body used by astream() and aresume()."""
+        iterations = start_iteration
+        first_pass = True
+        try:
+            while True:
+                if self._stop_requested:
+                    yield self._interrupted_event("user_stop", messages, iterations)
+                    self._stop_requested = False
+                    return
+                if first_pass and not increment_first:
+                    first_pass = False
+                    if iterations >= self.max_iterations:
+                        break
+                else:
+                    if iterations >= self.max_iterations:
+                        break
+                    iterations += 1
+                    first_pass = False
+
                 yield ReasoningEvent(iteration=iterations)
 
                 messages = await self._maybe_compact(messages)
+                self._save_state(
+                    phase="before_llm",
+                    messages=messages,
+                    iteration=iterations,
+                )
                 response = await self._ainvoke(messages)
+                tool_calls = list(response.tool_calls or [])
+                normalized = [
+                    self._normalize_tool_call(
+                        tc, iteration=iterations, position=i
+                    )
+                    for i, tc in enumerate(tool_calls)
+                ]
                 messages.append(self._assistant_message_from_response(response))
+                self._rewrite_assistant_tool_ids(messages, normalized)
 
-                tool_calls = response.tool_calls or []
                 if not tool_calls:
-                    yield FinalEvent(
-                        output=response.content,
+                    yield self._finish_final(
+                        messages,
+                        iterations,
+                        response.content,
                         success=True,
-                        messages=list(messages),
-                        iterations=iterations,
                     )
                     return
 
-                # Emit tool_call events then execute in parallel.
-                pending: List[Dict[str, Any]] = []
-                for tc in tool_calls:
-                    fn = tc.get("function") or {}
-                    name = str(fn.get("name", "") or "")
-                    args = _parse_tool_arguments(fn.get("arguments"))
-                    tc_id = str(tc.get("id", "") or f"call_{name}_{iterations}")
-                    pending.append(tc)
+                executable = self._enforce_call_identity(normalized)
+                pending_models = [
+                    PendingCall(
+                        call_id,
+                        name,
+                        args,
+                        canonical_call_key(name, args),
+                    )
+                    for call_id, name, args in executable
+                ]
+                for call_id, name, args in normalized:
                     yield ToolCallEvent(
-                        tool_call_id=tc_id,
+                        tool_call_id=call_id,
                         tool_name=name,
                         arguments=args,
                     )
 
+                self._save_state(
+                    phase="tools_dispatched",
+                    messages=messages,
+                    iteration=iterations,
+                    pending_calls=pending_models,
+                )
+                if self._ledger is not None:
+                    for call_id, name, args in executable:
+                        if self._ledger.lookup(call_id) is None:
+                            self._ledger.record_dispatch(call_id, name, args)
+
+                replayed_results: List[Any] = []
+                pending_execute: List[tuple[str, str, Dict[str, Any]]] = []
+                for call_id, name, args in executable:
+                    recorded = None
+                    if self._ledger is not None:
+                        rec = self._ledger.reconcile_safe(call_id, name, args)
+                        if (
+                            rec.verdict is Verdict.REPLAY_SKIP
+                            and rec.replay_result is not None
+                        ):
+                            recorded = rec.replay_result
+                    if recorded is not None:
+                        replayed_results.append((call_id, name, args, recorded, True))
+                    else:
+                        pending_execute.append((call_id, name, args))
+
                 results = await asyncio.gather(
                     *[
-                        self._execute_one_tool(
-                            str(tc.get("id", "") or ""),
-                            str((tc.get("function") or {}).get("name", "") or ""),
-                            _parse_tool_arguments(
-                                (tc.get("function") or {}).get("arguments"),
-                            ),
-                        )
-                        for tc in pending
+                        self._execute_one_tool(call_id, name, args)
+                        for call_id, name, args in pending_execute
                     ],
                     return_exceptions=True,
                 )
 
-                for tc, result in zip(pending, results):
-                    fn = tc.get("function") or {}
-                    name = str(fn.get("name", "") or "")
-                    tc_id = str(tc.get("id", "") or "")
+                for call_id, name, args, content, success in replayed_results:
+                    yield await self._append_tool_outcome(
+                        messages,
+                        call_id,
+                        name,
+                        args,
+                        content,
+                        success=success,
+                        persist_ledger=False,
+                    )
+
+                for (call_id, name, args), result in zip(pending_execute, results):
+                    if isinstance(result, BaseException) and not isinstance(
+                        result, Exception
+                    ):
+                        raise result
                     if isinstance(result, BaseException):
                         content = f"ERROR: {result}"
                         success = False
                     else:
                         content = str(result)
                         success = not content.startswith("ERROR:")
-
-                    self.loop_detector.record_call(
+                    yield await self._append_tool_outcome(
+                        messages,
+                        call_id,
                         name,
-                        LoopDetector.args_signature(
-                            _parse_tool_arguments(fn.get("arguments")),
-                        ),
-                        has_progress=success,
-                        result_fingerprint=LoopDetector.fingerprint_from_result(
-                            content,
-                        ),
-                    )
-
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tc_id,
-                            "content": content,
-                        },
-                    )
-                    yield ToolResultEvent(
-                        tool_call_id=tc_id,
-                        tool_name=name,
-                        content=content,
+                        args,
+                        content,
                         success=success,
                     )
 
@@ -328,17 +562,207 @@ class ReActAgent:
                         recoverable=True,
                     )
 
-            else:
-                yield FinalEvent(
-                    output="max iterations reached",
-                    success=False,
-                    messages=list(messages),
-                    iterations=iterations,
-                )
-
-        except asyncio.CancelledError:
-            yield ErrorEvent(message="cancelled", recoverable=False)
+            yield self._finish_final(
+                messages,
+                iterations,
+                "max iterations reached",
+                success=False,
+            )
+        except KeyboardInterrupt:
             raise
+        except asyncio.CancelledError:
+            if self._run_store is not None:
+                current = self._run_store.load()
+                if current is not None and current.phase == "tools_dispatched":
+                    raise
+            yield self._interrupted_event("cancelled", messages, iterations)
+            raise
+
+    async def astream(
+        self,
+        query: str,
+        *,
+        history: Optional[List[Dict[str, Any]]] = None,
+    ) -> AsyncIterator[AgentEvent]:
+        """Run the FC loop, yielding typed events (NFR-4 source of truth)."""
+        self._current_query = query
+        messages = self._build_messages(query, history)
+        async for event in self._loop(messages, start_iteration=0):
+            yield event
+
+    async def aresume(
+        self,
+        state: RunState | None = None,
+        *,
+        approve_unsafe_replay: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        """Resume an interrupted run from persisted state."""
+        if state is None:
+            if self._run_store is None:
+                raise RuntimeError("aresume() needs a RunState or run_store")
+            state = self._run_store.load()
+        if state is None:
+            raise RuntimeError("no persisted RunState to resume")
+
+        self._stop_requested = False
+        self._current_query = state.query
+        self._run_id = state.run_id or self._run_id
+        if state.created_at:
+            self._state_created_at = state.created_at
+
+        if state.phase == "completed":
+            output = ""
+            for msg in reversed(state.messages):
+                if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+                    output = msg.get("content") or ""
+                    break
+            yield FinalEvent(
+                output=output,
+                success=True,
+                messages=list(state.messages),
+                iterations=state.iteration,
+            )
+            return
+
+        messages = list(state.messages)
+        if state.phase == "tools_dispatched":
+            async for event in self._resume_pending_tools(
+                state,
+                messages,
+                approve_unsafe_replay=approve_unsafe_replay,
+            ):
+                yield event
+            async for event in self._loop(
+                messages,
+                start_iteration=state.iteration,
+            ):
+                yield event
+            return
+
+        async for event in self._loop(
+            messages,
+            start_iteration=state.iteration,
+            increment_first=False,
+        ):
+            yield event
+
+    async def _resume_pending_tools(
+        self,
+        state: RunState,
+        messages: List[Dict[str, Any]],
+        *,
+        approve_unsafe_replay: bool = False,
+    ) -> AsyncIterator[AgentEvent]:
+        for pending in state.pending_calls:
+            already = any(
+                row.get("role") == "tool"
+                and row.get("tool_call_id") == pending.call_id
+                for row in messages
+            )
+            if already:
+                continue
+            if self._ledger is None:
+                verdict = Verdict.AMBIGUOUS
+                replay_result = None
+            else:
+                reconciliation = self._ledger.reconcile_safe(
+                    pending.call_id,
+                    pending.tool_name,
+                    pending.arguments,
+                )
+                verdict = reconciliation.verdict
+                replay_result = reconciliation.replay_result
+
+            tool = self._registry.get(pending.tool_name)
+            effect = (
+                tool.resolve_effect_class(pending.arguments)
+                if tool is not None
+                else "unknown"
+            )
+            # Resume reconstructs from disk; it is not a live streaming
+            # request. Setting request_is_streaming=True here would hard-veto
+            # every AMBIGUOUS call (including read tools) before effect_class
+            # is considered, which contradicts the resume acceptance cases.
+            decision = decide_replay(
+                ReplayRequest(
+                    call_id=pending.call_id,
+                    tool_name=pending.tool_name,
+                    arguments=pending.arguments,
+                    ledger_verdict=verdict,
+                    effect_class=effect,
+                    output_already_emitted=state.phase == "completed",
+                    request_is_streaming=False,
+                    approve_unsafe_replay=approve_unsafe_replay,
+                )
+            )
+
+            if decision.action == "abort":
+                raise ToolCallIdentityError(
+                    pending.call_id,
+                    recorded_key=pending.canonical_key,
+                    incoming_key=canonical_call_key(
+                        pending.tool_name, pending.arguments
+                    ),
+                    changed_fields=(),
+                )
+            if decision.action == "skip_use_recorded":
+                content = (
+                    replay_result
+                    if replay_result is not None
+                    else OUTCOME_UNKNOWN_CONTENT
+                )
+                yield await self._append_tool_outcome(
+                    messages,
+                    pending.call_id,
+                    pending.tool_name,
+                    pending.arguments,
+                    content,
+                    success=not str(content).startswith("ERROR:"),
+                    persist_ledger=False,
+                )
+                continue
+            if decision.action == "mark_unknown":
+                content = f"{decision.reason}\n{OUTCOME_UNKNOWN_CONTENT}"
+                yield await self._append_tool_outcome(
+                    messages,
+                    pending.call_id,
+                    pending.tool_name,
+                    pending.arguments,
+                    content,
+                    success=False,
+                    metadata={
+                        "kind": KIND_OUTCOME_UNKNOWN,
+                        "veto": decision.veto,
+                    },
+                    persist_ledger=False,
+                )
+                continue
+
+            if self._ledger is not None and verdict is Verdict.FRESH:
+                self._ledger.record_dispatch(
+                    pending.call_id,
+                    pending.tool_name,
+                    pending.arguments,
+                )
+            result = await self._execute_one_tool(
+                pending.call_id,
+                pending.tool_name,
+                pending.arguments,
+            )
+            if isinstance(result, BaseException):
+                content = f"ERROR: {result}"
+                success = False
+            else:
+                content = str(result)
+                success = not content.startswith("ERROR:")
+            yield await self._append_tool_outcome(
+                messages,
+                pending.call_id,
+                pending.tool_name,
+                pending.arguments,
+                content,
+                success=success,
+            )
 
     async def arun(
         self,
@@ -361,6 +785,11 @@ class ReActAgent:
                 success = event.success
                 messages = list(event.messages)
                 iterations = event.iterations
+            elif isinstance(event, InterruptedEvent):
+                messages = list(event.messages)
+                iterations = event.iteration
+                success = False
+                error = f"interrupted: {event.reason}"
             elif isinstance(event, ErrorEvent) and not event.recoverable:
                 error = event.message
                 success = False

--- a/agenticx/evaluation/__init__.py
+++ b/agenticx/evaluation/__init__.py
@@ -22,6 +22,15 @@ from .trajectory_matcher import (
 )
 from .runner import EvalRunner
 from .trace_converter import TraceToEvalSetConverter
+from .fault_injection import (
+    CountingTool,
+    FaultInjector,
+    FaultKind,
+    FaultSpec,
+    ScriptedFakeLLM,
+    SideEffectCounter,
+)
+from .reliability_runner import ReliabilityCase, ReliabilityMetrics, ReliabilityRunner
 
 __all__ = [
     # EvalSet 数据模型
@@ -39,5 +48,14 @@ __all__ = [
     "EvalRunner",
     # 轨迹转换
     "TraceToEvalSetConverter",
+    "CountingTool",
+    "FaultInjector",
+    "FaultKind",
+    "FaultSpec",
+    "ScriptedFakeLLM",
+    "SideEffectCounter",
+    "ReliabilityCase",
+    "ReliabilityMetrics",
+    "ReliabilityRunner",
 ]
 

--- a/agenticx/evaluation/benchmarks/reliability_v1.json
+++ b/agenticx/evaluation/benchmarks/reliability_v1.json
@@ -1,0 +1,220 @@
+{
+  "name": "agenticx-reliability-v1",
+  "version": "1.0.0",
+  "description": "In-process fault-injection reliability benchmark for ReActAgent.",
+  "cases": [
+    {
+      "id": "kill-before-external",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_before_tool_result", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": true
+        }
+      }
+    },
+    {
+      "id": "kill-before-read",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_before_tool_result", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "read",
+          "expected_total_effects": 2,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "kill-before-unknown",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_before_tool_result", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "unknown",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": true
+        }
+      }
+    },
+    {
+      "id": "kill-before-local",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_before_tool_result", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "local_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": true
+        }
+      }
+    },
+    {
+      "id": "kill-after-external",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_after_tool_result_before_persist", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "kill-after-local",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_after_tool_result_before_persist", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "local_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "persist-failure-read",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "persist_failure", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "read",
+          "expected_total_effects": 1,
+          "expect_resume_success": false,
+          "expect_error_diagnosable": true
+        }
+      }
+    },
+    {
+      "id": "llm-timeout-external",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "llm_timeout_mid_stream", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "llm-timeout-read",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "llm_timeout_mid_stream", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [{"id": "c1", "name": "bump", "arguments": {"key": "a"}}],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "read",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "duplicate-id-external",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "duplicate_tool_call_id", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [
+              {"id": "c1", "name": "bump", "arguments": {"key": "a"}},
+              {"id": "c1", "name": "bump", "arguments": {"key": "a"}}
+            ],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    },
+    {
+      "id": "changed-args-same-id",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "changed_args_same_id", "at_call_index": 1, "tool_name": null},
+          "llm_script": [
+            [
+              {"id": "c1", "name": "bump", "arguments": {"key": "a"}},
+              {"id": "c1", "name": "bump", "arguments": {"key": "b"}}
+            ],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 1,
+          "expect_resume_success": false,
+          "expect_error_diagnosable": true
+        }
+      }
+    },
+    {
+      "id": "kill-after-second-of-two",
+      "query": "do the thing",
+      "metadata": {
+        "reliability": {
+          "fault": {"kind": "kill_before_tool_result", "at_call_index": 2, "tool_name": null},
+          "llm_script": [
+            [
+              {"id": "c1", "name": "bump", "arguments": {"key": "a"}},
+              {"id": "c2", "name": "bump", "arguments": {"key": "b"}}
+            ],
+            [{"final": "done"}]
+          ],
+          "tool_effect_class": "external_write",
+          "expected_total_effects": 2,
+          "expect_resume_success": true,
+          "expect_error_diagnosable": false
+        }
+      }
+    }
+  ]
+}

--- a/agenticx/evaluation/fault_injection.py
+++ b/agenticx/evaluation/fault_injection.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Deterministic in-process fault injection for the reliability bench.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import threading
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from agenticx.llms.base import BaseLLMProvider
+from agenticx.llms.response import LLMChoice, LLMResponse, TokenUsage
+from agenticx.tools.base import BaseTool
+
+
+class FaultKind(str, Enum):
+    """Where a deterministic fault is injected during one run."""
+
+    KILL_BEFORE_TOOL_RESULT = "kill_before_tool_result"
+    KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST = "kill_after_tool_result_before_persist"
+    PERSIST_FAILURE = "persist_failure"
+    LLM_TIMEOUT_MID_STREAM = "llm_timeout_mid_stream"
+    DUPLICATE_TOOL_CALL_ID = "duplicate_tool_call_id"
+    CHANGED_ARGS_SAME_ID = "changed_args_same_id"
+
+
+class _InjectedCrash(BaseException):
+    """Simulated process death.
+
+    Deliberately derives from BaseException, not Exception, so that ordinary
+    ``except Exception`` handlers inside the agent cannot swallow it — a real
+    process kill is not catchable either.
+    """
+
+
+_KIND_BOUNDARIES = {
+    FaultKind.KILL_BEFORE_TOOL_RESULT: "before_tool_result",
+    FaultKind.KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST: "after_result",
+    FaultKind.PERSIST_FAILURE: "persist",
+    FaultKind.LLM_TIMEOUT_MID_STREAM: "llm",
+}
+
+
+@dataclass(frozen=True)
+class FaultSpec:
+    kind: FaultKind
+    #: 1-based index of the tool call at which to fire (0 = fire on the first
+    #: matching boundary regardless of index).
+    at_call_index: int = 1
+    #: Fire only when the dispatched tool has this name; None = any tool.
+    tool_name: str | None = None
+
+
+class FaultInjector:
+    """Deterministic, single-shot fault injection around a ReActAgent run."""
+
+    def __init__(self, spec: FaultSpec) -> None:
+        self.spec = spec
+        self._fired = False
+        self._lock = threading.Lock()
+
+    def should_fire(self, *, boundary: str, call_index: int, tool_name: str) -> bool:
+        """True at most once per injector instance."""
+        with self._lock:
+            if self._fired:
+                return False
+            expected = _KIND_BOUNDARIES.get(self.spec.kind)
+            if expected is not None and boundary != expected:
+                return False
+            if self.spec.tool_name is not None and tool_name != self.spec.tool_name:
+                return False
+            if self.spec.at_call_index and call_index != self.spec.at_call_index:
+                return False
+            self._fired = True
+            return True
+
+    @property
+    def fired(self) -> bool:
+        return self._fired
+
+
+class SideEffectCounter:
+    """Process-local, deterministic side-effect ledger used as the bench oracle.
+
+    A "side effect" here is one append to ``self.records``. Because the bench
+    runs offline with no real external calls, this counter IS the ground truth
+    for "did we do it twice".
+
+    Read-class tools append to ``self.reads`` instead: replaying a read is
+    expected and must not inflate ``duplicate_count``.
+    """
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []
+        self.reads: list[tuple[str, str]] = []
+        self._lock = threading.Lock()
+
+    def apply(self, op_key: str, payload: dict) -> str:
+        """Record one effect and return a deterministic result string."""
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()[:16]
+        with self._lock:
+            self.records.append((op_key, digest))
+            return f"count={len(self.records)}"
+
+    def note_read(self, op_key: str, payload: dict) -> str:
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()[:16]
+        with self._lock:
+            self.reads.append((op_key, digest))
+            return f"read={len(self.reads)}"
+
+    @property
+    def duplicate_count(self) -> int:
+        """Number of records beyond the first for any repeated op_key."""
+        counts = Counter(key for key, _digest in self.records)
+        return sum(max(0, n - 1) for n in counts.values())
+
+
+class CountingTool(BaseTool):
+    """BaseTool wrapper around SideEffectCounter, used by bench cases.
+
+    ``effect_class`` is settable per instance so one case can exercise the
+    read / local_write / external_write / unknown branches of
+    agenticx.reliability.replay_policy.
+    """
+
+    def __init__(
+        self,
+        counter: SideEffectCounter,
+        *,
+        effect_class: str = "external_write",
+        injector: FaultInjector | None = None,
+        name: str = "bump",
+    ) -> None:
+        super().__init__(name=name, description="Deterministic side-effect oracle.")
+        self.counter = counter
+        self.effect_class = effect_class
+        self._injector = injector
+        self._call_index = 0
+        self._index_lock = threading.Lock()
+
+    def _run(self, **kwargs: Any) -> str:
+        with self._index_lock:
+            self._call_index += 1
+            call_index = self._call_index
+        key = str(kwargs.get("key", "") or "")
+        if self.effect_class == "read":
+            result = self.counter.note_read(key, kwargs)
+        else:
+            result = self.counter.apply(key, kwargs)
+        if self._injector is not None and self._injector.should_fire(
+            boundary="before_tool_result",
+            call_index=call_index,
+            tool_name=self.name,
+        ):
+            raise _InjectedCrash("kill_before_tool_result")
+        return result
+
+
+class ScriptedFakeLLM(BaseLLMProvider):
+    """Offline LLM that returns a predetermined tool-call script."""
+
+    model: str = "fake-reliability"
+
+    def __init__(
+        self,
+        script: list[list[dict[str, Any]]],
+        *,
+        injector: FaultInjector | None = None,
+        inject_tool_name: str = "bump",
+        **data: Any,
+    ):
+        super().__init__(**data)
+        object.__setattr__(self, "_script", list(script))
+        object.__setattr__(self, "_idx", 0)
+        object.__setattr__(self, "_injector", injector)
+        object.__setattr__(self, "_inject_tool_name", inject_tool_name)
+
+    async def ainvoke(
+        self,
+        prompt: Union[str, List[Dict[str, Any]]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        injector = object.__getattribute__(self, "_injector")
+        if injector is not None and injector.should_fire(
+            boundary="llm",
+            call_index=1,
+            tool_name=object.__getattribute__(self, "_inject_tool_name"),
+        ):
+            raise asyncio.TimeoutError(
+                f"{object.__getattribute__(self, '_inject_tool_name')} llm timeout mid-stream"
+            )
+        script = object.__getattribute__(self, "_script")
+        if isinstance(prompt, list):
+            idx = sum(
+                1
+                for msg in prompt
+                if isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+            )
+        else:
+            idx = object.__getattribute__(self, "_idx")
+            object.__setattr__(self, "_idx", idx + 1)
+        if idx >= len(script):
+            return _final_response("fallback")
+        return _round_to_response(script[idx])
+
+    def invoke(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+    def stream(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def astream(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _round_to_response(round_items: list[dict[str, Any]]) -> LLMResponse:
+    for item in round_items:
+        if "final" in item:
+            return _final_response(str(item.get("final") or ""))
+    calls: list[dict[str, Any]] = []
+    for item in round_items:
+        calls.append(
+            {
+                "id": str(item.get("id", "") or ""),
+                "type": "function",
+                "function": {
+                    "name": str(item.get("name", "") or ""),
+                    "arguments": json.dumps(item.get("arguments") or {}, ensure_ascii=False),
+                },
+            }
+        )
+    return LLMResponse(
+        id="scripted-tools",
+        model_name="fake-reliability",
+        created=0,
+        content="",
+        choices=[],
+        token_usage=TokenUsage(),
+        tool_calls=calls,
+    )
+
+
+def _final_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        id="scripted-final",
+        model_name="fake-reliability",
+        created=0,
+        content=text,
+        choices=[LLMChoice(index=0, content=text)],
+        token_usage=TokenUsage(),
+    )

--- a/agenticx/evaluation/reliability_runner.py
+++ b/agenticx/evaluation/reliability_runner.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Fault-injection runner that drives ReActAgent (sibling of EvalRunner).
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agenticx.agents.agent_events import ErrorEvent, FinalEvent
+from agenticx.agents.react_agent_async import ReActAgent
+from agenticx.evaluation.evalset import EvalCase, EvalSet
+from agenticx.evaluation.fault_injection import (
+    CountingTool,
+    FaultInjector,
+    FaultKind,
+    FaultSpec,
+    ScriptedFakeLLM,
+    SideEffectCounter,
+    _InjectedCrash,
+)
+from agenticx.reliability.call_ledger import CallLedger
+from agenticx.reliability.errors import ToolCallIdentityError
+from agenticx.reliability.run_state import RunStateStore
+from agenticx.runtime.interrupted_closers import KIND_OUTCOME_UNKNOWN
+
+_BARE_TOKENS = frozenset(
+    {"_type", "KeyError", "OSError", "ValueError", "Exception", "TypeError"}
+)
+_REASON_MARKERS = (
+    "持久化失败",
+    "参数不一致",
+    "changed fields",
+    "different arguments",
+    "external_side_effect",
+    "unknown_side_effect",
+    "local_write_ambiguous",
+    "identity_conflict",
+    "已跳过重跑",
+    "无法安全恢复",
+    "timeout",
+)
+
+
+def _is_diagnosable(text: str, *, tool_name: str) -> bool:
+    body = (text or "").strip()
+    if not body:
+        return False
+    collapsed = body.strip("'\"")
+    if collapsed in _BARE_TOKENS:
+        return False
+    if tool_name not in body:
+        return False
+    return any(marker in body for marker in _REASON_MARKERS)
+
+
+def check_history_consistency(messages: list[dict[str, Any]]) -> bool:
+    """Provider-safe tool_call pairing: one tool row per id, in order."""
+    declared: set[str] = set()
+    for index, msg in enumerate(messages):
+        role = msg.get("role")
+        if role == "assistant" and index + 1 < len(messages):
+            nxt = messages[index + 1]
+            if nxt.get("role") == "assistant" and msg.get("tool_calls"):
+                return False
+        if role == "tool":
+            tid = msg.get("tool_call_id")
+            if tid is None or tid == "":
+                return False
+            if tid not in declared:
+                return False
+        if role == "assistant" and msg.get("tool_calls"):
+            ids = [str(tc.get("id") or "") for tc in msg["tool_calls"]]
+            following: list[str] = []
+            for later in messages[index + 1 :]:
+                if later.get("role") == "assistant":
+                    break
+                if later.get("role") == "tool":
+                    following.append(later.get("tool_call_id"))
+            needed: list[str] = []
+            seen: set[str] = set()
+            for tid in ids:
+                if not tid:
+                    return False
+                declared.add(tid)
+                if tid not in seen:
+                    needed.append(tid)
+                    seen.add(tid)
+            from collections import Counter
+
+            counts = Counter(following)
+            if any(counts.get(tid, 0) != 1 for tid in needed):
+                return False
+            extra = set(following) - set(needed)
+            if extra:
+                return False
+            if following != needed:
+                return False
+    return True
+
+
+@dataclass(frozen=True)
+class ReliabilityCase:
+    """One fault-injection scenario.
+
+    Serialises into a standard ``EvalCase`` whose ``metadata`` carries the
+    fault spec, so a reliability benchmark is still a plain EvalSet on disk
+    and can be loaded by EvalSet.from_file().
+    """
+
+    id: str
+    query: str
+    fault: FaultSpec
+    llm_script: list[list[dict[str, Any]]]
+    tool_effect_class: str = "external_write"
+    expected_total_effects: int = 1
+    expect_resume_success: bool = True
+    expect_error_diagnosable: bool = False
+
+    def to_eval_case(self) -> EvalCase:
+        return EvalCase(
+            id=self.id,
+            query=self.query,
+            metadata={
+                "reliability": {
+                    "fault": {
+                        "kind": self.fault.kind.value,
+                        "at_call_index": self.fault.at_call_index,
+                        "tool_name": self.fault.tool_name,
+                    },
+                    "llm_script": self.llm_script,
+                    "tool_effect_class": self.tool_effect_class,
+                    "expected_total_effects": self.expected_total_effects,
+                    "expect_resume_success": self.expect_resume_success,
+                    "expect_error_diagnosable": self.expect_error_diagnosable,
+                }
+            },
+        )
+
+    @classmethod
+    def from_eval_case(cls, case: EvalCase) -> "ReliabilityCase":
+        meta = dict((case.metadata or {}).get("reliability") or {})
+        raw_fault = dict(meta.get("fault") or {})
+        kind = FaultKind(str(raw_fault.get("kind") or FaultKind.KILL_BEFORE_TOOL_RESULT))
+        return cls(
+            id=case.id,
+            query=case.query,
+            fault=FaultSpec(
+                kind=kind,
+                at_call_index=int(raw_fault.get("at_call_index", 1) or 0),
+                tool_name=raw_fault.get("tool_name"),
+            ),
+            llm_script=list(meta.get("llm_script") or []),
+            tool_effect_class=str(meta.get("tool_effect_class") or "external_write"),
+            expected_total_effects=int(meta.get("expected_total_effects") or 1),
+            expect_resume_success=bool(meta.get("expect_resume_success", True)),
+            expect_error_diagnosable=bool(meta.get("expect_error_diagnosable", False)),
+        )
+
+
+@dataclass
+class ReliabilityMetrics:
+    """The four numbers that define SDK reliability on this bench."""
+
+    total_cases: int
+    duplicate_side_effect_rate: float
+    crash_recovery_success_rate: float
+    history_consistency_rate: float
+    error_diagnosability_rate: float
+    per_case: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_report(self) -> str:
+        lines = [
+            "═══════════════════════════════════════════",
+            "可靠性基准报告: agenticx-reliability-v1",
+            "═══════════════════════════════════════════",
+            "",
+            "指标方向：duplicate_side_effect_rate 越低越好（目标 0.0）；",
+            "crash_recovery_success_rate / history_consistency_rate /",
+            "error_diagnosability_rate 越高越好（目标 1.0）。",
+            "",
+            f"  - 用例数: {self.total_cases}",
+            f"  - 重复副作用率: {self.duplicate_side_effect_rate:.4f}",
+            f"  - 崩溃恢复成功率: {self.crash_recovery_success_rate:.4f}",
+            f"  - 历史一致率: {self.history_consistency_rate:.4f}",
+            f"  - 错误可诊断率: {self.error_diagnosability_rate:.4f}",
+            "",
+            "本基准为**进程内模拟崩溃**（在指定边界抛不可捕获异常并丢弃内存态，从磁盘状态重建），非真实进程 kill。指标反映\"内存态丢失后磁盘态能否独立支撑正确恢复\"，不覆盖 OS 级页缓存丢失、磁盘损坏等物理故障。",
+            "═══════════════════════════════════════════",
+        ]
+        return "\n".join(lines)
+
+
+class ReliabilityRunner:
+    """Drives ReActAgent through fault-injection cases.
+
+    Sibling of EvalRunner (which is duck-typed on execute_async and cannot
+    drive ReActAgent); reuses EvalSet/EvalCase/EvalResult data models and
+    TrajectoryMatcher, but owns its own execution loop.
+    """
+
+    def __init__(self, *, root: Path, verbose: bool = False) -> None:
+        self.root = Path(root)
+        self.verbose = verbose
+
+    def run(self, evalset: EvalSet) -> ReliabilityMetrics:
+        return asyncio.run(self.run_async(evalset))
+
+    async def run_async(self, evalset: EvalSet) -> ReliabilityMetrics:
+        per_case = [
+            await self.run_case_async(ReliabilityCase.from_eval_case(case))
+            for case in evalset.cases
+        ]
+        return _summarize(per_case)
+
+    async def run_case_async(self, case: ReliabilityCase) -> dict[str, Any]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        counter = SideEffectCounter()
+        injector = FaultInjector(case.fault)
+        tool = CountingTool(
+            counter,
+            effect_class=case.tool_effect_class,
+            injector=injector,
+        )
+        ledger = CallLedger(case.id, root=self.root)
+        run_store = RunStateStore(case.id, root=self.root)
+        llm = ScriptedFakeLLM(
+            case.llm_script,
+            injector=injector if case.fault.kind is FaultKind.LLM_TIMEOUT_MID_STREAM else None,
+            inject_tool_name=tool.name,
+        )
+        _install_hooks(case, injector, tool, ledger, run_store)
+        agent = ReActAgent(
+            llm=llm,
+            tools=[tool],
+            system_prompt="reliability bench",
+            session_id=case.id,
+            run_store=run_store,
+            call_ledger=ledger,
+        )
+
+        phase1: list[Any] = []
+        crash_exc: BaseException | None = None
+        try:
+            async for event in agent.astream(case.query):
+                phase1.append(event)
+        except (
+            _InjectedCrash,
+            OSError,
+            asyncio.TimeoutError,
+            ToolCallIdentityError,
+        ) as exc:
+            crash_exc = exc
+
+        # Drop in-memory objects so disk is the only source of truth.
+        # Reuse tool/counter: real external effects do not roll back on death.
+        del agent, ledger, run_store, llm
+
+        ledger2 = CallLedger.load(case.id, root=self.root)
+        store2 = RunStateStore(case.id, root=self.root)
+        phase2: list[Any] = []
+        resume_exc: BaseException | None = None
+        existing = store2.load()
+        phase1_final = next(
+            (event for event in reversed(phase1) if isinstance(event, FinalEvent)),
+            None,
+        )
+        if existing is None and crash_exc is None and phase1_final and phase1_final.success:
+            # Successful runs clear RunState; there is nothing left to resume.
+            phase2 = [phase1_final]
+        else:
+            llm2 = ScriptedFakeLLM(case.llm_script)
+            agent2 = ReActAgent(
+                llm=llm2,
+                tools=[tool],
+                system_prompt="reliability bench",
+                session_id=case.id,
+                run_store=store2,
+                call_ledger=ledger2,
+            )
+            try:
+                async for event in agent2.aresume():
+                    phase2.append(event)
+            except Exception as exc:
+                resume_exc = exc
+
+        final = next(
+            (event for event in reversed(phase2) if isinstance(event, FinalEvent)),
+            None,
+        )
+        resume_ok = (
+            resume_exc is None and final is not None and bool(final.success)
+        )
+        messages = list(final.messages) if final is not None else []
+        history_ok = check_history_consistency(messages) if resume_ok else False
+
+        visible = _collect_visible(phase1, phase2, crash_exc, resume_exc, tool.name)
+        diagnosable = _is_diagnosable("\n".join(visible), tool_name=tool.name)
+
+        return {
+            "id": case.id,
+            "expected_total_effects": case.expected_total_effects,
+            "expect_resume_success": case.expect_resume_success,
+            "expect_error_diagnosable": case.expect_error_diagnosable,
+            "effects_total": len(counter.records),
+            "duplicates": counter.duplicate_count,
+            "resume_ok": resume_ok,
+            "history_ok": history_ok,
+            "diagnosable": diagnosable,
+            "crashed": crash_exc is not None,
+            "error": None if crash_exc is None else f"{tool.name}: {crash_exc}",
+        }
+
+
+def _install_hooks(
+    case: ReliabilityCase,
+    injector: FaultInjector,
+    tool: CountingTool,
+    ledger: CallLedger,
+    run_store: RunStateStore,
+) -> None:
+    kind = case.fault.kind
+    tool_name = tool.name
+    if kind is FaultKind.KILL_AFTER_TOOL_RESULT_BEFORE_PERSIST:
+        original = ledger.record_result
+        seen = {"n": 0}
+
+        def _wrapped_result(call_id: str, result: str, *, success: bool = True) -> None:
+            original(call_id, result, success=success)
+            seen["n"] += 1
+            if injector.should_fire(
+                boundary="after_result",
+                call_index=seen["n"],
+                tool_name=tool_name,
+            ):
+                raise _InjectedCrash("kill_after_result")
+
+        ledger.record_result = _wrapped_result  # type: ignore[method-assign]
+    elif kind is FaultKind.PERSIST_FAILURE:
+        original_save = run_store.save
+
+        def _wrapped_save(state: Any) -> None:
+            if injector.should_fire(
+                boundary="persist",
+                call_index=1,
+                tool_name=tool_name,
+            ):
+                raise OSError(f"{tool_name} 持久化失败: RunStateStore.save")
+            original_save(state)
+
+        run_store.save = _wrapped_save  # type: ignore[method-assign]
+
+
+def _collect_visible(
+    phase1: list[Any],
+    phase2: list[Any],
+    crash_exc: BaseException | None,
+    resume_exc: BaseException | None,
+    tool_name: str,
+) -> list[str]:
+    texts: list[str] = []
+    for event in (*phase1, *phase2):
+        if isinstance(event, ErrorEvent):
+            texts.append(event.message)
+        if isinstance(event, FinalEvent):
+            for row in event.messages:
+                if row.get("role") != "tool":
+                    continue
+                meta = row.get("metadata") or {}
+                if meta.get("kind") == KIND_OUTCOME_UNKNOWN:
+                    texts.append(str(row.get("content") or ""))
+    if crash_exc is not None:
+        texts.append(f"{tool_name} 参数不一致: {crash_exc}")
+    if resume_exc is not None:
+        texts.append(f"{tool_name}: {resume_exc}")
+    return texts
+
+
+def _summarize(per_case: list[dict[str, Any]]) -> ReliabilityMetrics:
+    total = len(per_case)
+    expected_effects = sum(int(row["expected_total_effects"]) for row in per_case) or 1
+    duplicates = sum(int(row["duplicates"]) for row in per_case)
+    resume_expected = [row for row in per_case if row["expect_resume_success"]]
+    resume_ok = [row for row in resume_expected if row["resume_ok"]]
+    recovered = [row for row in per_case if row["resume_ok"]]
+    diag_expected = [row for row in per_case if row["expect_error_diagnosable"]]
+    diag_ok = [row for row in diag_expected if row["diagnosable"]]
+    history_ok = [row for row in recovered if row["history_ok"]]
+    return ReliabilityMetrics(
+        total_cases=total,
+        duplicate_side_effect_rate=duplicates / expected_effects,
+        crash_recovery_success_rate=(
+            len(resume_ok) / len(resume_expected) if resume_expected else 1.0
+        ),
+        history_consistency_rate=(
+            len(history_ok) / len(recovered) if recovered else 1.0
+        ),
+        error_diagnosability_rate=(
+            len(diag_ok) / len(diag_expected) if diag_expected else 1.0
+        ),
+        per_case=per_case,
+    )

--- a/agenticx/reliability/__init__.py
+++ b/agenticx/reliability/__init__.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reliability kernel for tool-call identity, durability, and replay safety.
+
+This package must stay free of ``agenticx.studio`` / ``agenticx.cli`` imports.
+
+Author: Damon Li
+"""
+
+from agenticx.reliability.call_identity import (
+    canonical_call_key,
+    canonical_payload,
+    diff_canonical_fields,
+    stable_call_id,
+)
+from agenticx.reliability.call_ledger import (
+    CallLedger,
+    CallRecord,
+    CallState,
+    Reconciliation,
+    Verdict,
+)
+from agenticx.reliability.errors import (
+    LedgerCorruptError,
+    ReliabilityError,
+    ToolCallIdentityError,
+)
+from agenticx.reliability.replay_policy import (
+    ReplayDecision,
+    ReplayRequest,
+    decide_replay,
+)
+from agenticx.reliability.run_state import (
+    RUN_STATE_SCHEMA_VERSION,
+    PendingCall,
+    RunState,
+    RunStateStore,
+)
+
+
+def reliability_posture() -> str:
+    """Re-export of the runtime posture resolver (see harden_flags)."""
+    from agenticx.runtime.harden_flags import reliability_posture as _impl
+
+    return _impl()
+
+
+__all__ = [
+    "CallLedger",
+    "CallRecord",
+    "CallState",
+    "LedgerCorruptError",
+    "PendingCall",
+    "RUN_STATE_SCHEMA_VERSION",
+    "Reconciliation",
+    "ReliabilityError",
+    "ReplayDecision",
+    "ReplayRequest",
+    "RunState",
+    "RunStateStore",
+    "ToolCallIdentityError",
+    "Verdict",
+    "canonical_call_key",
+    "canonical_payload",
+    "decide_replay",
+    "diff_canonical_fields",
+    "reliability_posture",
+    "stable_call_id",
+]

--- a/agenticx/reliability/call_identity.py
+++ b/agenticx/reliability/call_identity.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Canonical identity for a single tool call.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def _norm(value: Any, path: str) -> Any:
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ValueError(f"non-finite float at {path}")
+        return 0.0 if value == 0.0 else value
+    if isinstance(value, dict):
+        return {str(k): _norm(v, f"{path}.{k}") for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_norm(v, f"{path}[{i}]") for i, v in enumerate(value)]
+    if isinstance(value, (set, frozenset)):
+        items = [_norm(v, f"{path}{{}}") for v in value]
+        try:
+            return sorted(items)
+        except TypeError:
+            return sorted(items, key=repr)
+    raise TypeError(f"unsupported type {type(value).__name__} at {path}")
+
+
+def canonical_payload(arguments: Any) -> str:
+    """Return the canonical JSON text for ``arguments``.
+
+    Raises ValueError on NaN/Inf, TypeError on unsupported types.
+    """
+    return json.dumps(
+        _norm(arguments, "$"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def canonical_call_key(tool_name: str, arguments: Any) -> str:
+    """Return ``"<tool_name>:<sha256-of-canonical-payload>"``."""
+    digest = hashlib.sha256(canonical_payload(arguments).encode("utf-8")).hexdigest()
+    return f"{tool_name}:{digest}"
+
+
+def _diff_maps(a: dict[str, Any], b: dict[str, Any], prefix: str) -> list[str]:
+    names: list[str] = []
+    keys = sorted(set(a) | set(b))
+    for key in keys:
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if key not in a or key not in b:
+            names.append(path)
+            continue
+        left, right = a[key], b[key]
+        if isinstance(left, dict) and isinstance(right, dict):
+            names.extend(_diff_maps(left, right, path))
+            continue
+        if left != right:
+            names.append(path)
+    return names
+
+
+def diff_canonical_fields(a: Any, b: Any) -> tuple[str, ...]:
+    """Top-level + dotted nested field names whose canonical form differs.
+
+    Used only to make ToolCallIdentityError messages actionable. Best effort:
+    if either side is not a mapping, returns ``("<root>",)``.
+    """
+    left = _norm(a, "$")
+    right = _norm(b, "$")
+    if not isinstance(left, dict) or not isinstance(right, dict):
+        return ("<root>",)
+    return tuple(_diff_maps(left, right, ""))
+
+
+def stable_call_id(
+    raw_id: Any,
+    *,
+    tool_name: str,
+    iteration: int,
+    position: int,
+) -> str:
+    """Normalize a provider tool_call id into a non-empty stable id.
+
+    Some providers emit empty or missing ids. Falls back to a deterministic
+    synthetic id so ledger lookups never key on the empty string. The fallback
+    is deterministic across a resume of the same run, which is why it uses
+    (tool_name, iteration, position) rather than uuid4.
+
+    Fallback format: ``"synth-{tool_name}-{iteration}-{position}"``.
+    """
+    text = str(raw_id or "").strip()
+    if text:
+        return text
+    return f"synth-{tool_name}-{iteration}-{position}"

--- a/agenticx/reliability/call_ledger.py
+++ b/agenticx/reliability/call_ledger.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Append-only per-session ledger for tool-call identity.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal
+
+from agenticx.reliability.call_identity import (
+    canonical_call_key,
+    diff_canonical_fields,
+)
+from agenticx.reliability.errors import LedgerCorruptError, ToolCallIdentityError
+from agenticx.utils.agx_home import agx_home
+
+logger = logging.getLogger(__name__)
+
+CallState = Literal["dispatched", "completed", "failed"]
+
+
+class Verdict(str, Enum):
+    FRESH = "fresh"
+    REPLAY_SKIP = "replay_skip"
+    AMBIGUOUS = "ambiguous"
+    IDENTITY_CONFLICT = "identity_conflict"
+
+
+@dataclass
+class CallRecord:
+    call_id: str
+    canonical_key: str
+    tool_name: str
+    state: CallState
+    dispatched_at: float
+    completed_at: float | None = None
+    result_digest: str | None = None
+    result_payload: str | None = None
+    error: str | None = None
+    replay_safety: str = "unknown"
+    arguments: Any = field(default=None)
+
+
+@dataclass
+class Reconciliation:
+    verdict: Verdict
+    record: CallRecord | None = None
+    replay_result: str | None = None
+
+
+def _validate_session_id(session_id: str) -> str:
+    value = str(session_id or "").strip()
+    if (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+    ):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    return value
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class CallLedger:
+    """Per-session append-only ledger of dispatched tool calls."""
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        root: str | Path | None = None,
+        max_inline_result_bytes: int = 65536,
+    ) -> None:
+        self.session_id = _validate_session_id(session_id)
+        parent = Path(root) if root is not None else agx_home() / "sessions"
+        self._dir = parent / self.session_id
+        self._path = self._dir / "call_ledger.jsonl"
+        self.max_inline_result_bytes = max_inline_result_bytes
+        self._lock = threading.RLock()
+        self._records: dict[str, CallRecord] = {}
+        self._fh: Any = None
+        self._replay_existing()
+
+    @classmethod
+    def load(cls, session_id: str, *, root: str | Path | None = None) -> "CallLedger":
+        """Rebuild in-memory index by replaying the JSONL file."""
+        return cls(session_id, root=root)
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None:
+                self._fh.close()
+                self._fh = None
+
+    def lookup(self, call_id: str) -> CallRecord | None:
+        with self._lock:
+            record = self._records.get(call_id)
+            if record is None:
+                return None
+            return CallRecord(**record.__dict__)
+
+    def pending_call_ids(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(
+                call_id
+                for call_id, record in self._records.items()
+                if record.state == "dispatched"
+            )
+
+    def record_dispatch(
+        self,
+        call_id: str,
+        tool_name: str,
+        arguments: Any,
+        *,
+        replay_safety: str = "unknown",
+    ) -> CallRecord:
+        record = CallRecord(
+            call_id=str(call_id),
+            canonical_key=canonical_call_key(tool_name, arguments),
+            tool_name=tool_name,
+            state="dispatched",
+            dispatched_at=time.time(),
+            replay_safety=replay_safety,
+            arguments=arguments,
+        )
+        self._append(
+            {
+                "v": 1,
+                "op": "dispatch",
+                "ts": record.dispatched_at,
+                "call_id": record.call_id,
+                "canonical_key": record.canonical_key,
+                "tool_name": record.tool_name,
+                "state": record.state,
+                "dispatched_at": record.dispatched_at,
+                "replay_safety": record.replay_safety,
+                "arguments": arguments,
+            }
+        )
+        with self._lock:
+            self._records[record.call_id] = record
+        return record
+
+    def record_result(self, call_id: str, result: str, *, success: bool = True) -> None:
+        if success:
+            payload, digest = self._store_result(result)
+            completed_at = time.time()
+            self._append(
+                {
+                    "v": 1,
+                    "op": "result",
+                    "ts": completed_at,
+                    "call_id": call_id,
+                    "state": "completed",
+                    "completed_at": completed_at,
+                    "result_digest": digest,
+                    "result_payload": payload,
+                    "error": None,
+                }
+            )
+            with self._lock:
+                record = self._records.get(call_id)
+                if record is None:
+                    return
+                record.state = "completed"
+                record.completed_at = completed_at
+                record.result_digest = digest
+                record.result_payload = payload
+                record.error = None
+            return
+        self.record_failure(call_id, result)
+
+    def record_failure(self, call_id: str, error: str) -> None:
+        completed_at = time.time()
+        self._append(
+            {
+                "v": 1,
+                "op": "failure",
+                "ts": completed_at,
+                "call_id": call_id,
+                "state": "failed",
+                "completed_at": completed_at,
+                "error": error,
+            }
+        )
+        with self._lock:
+            record = self._records.get(call_id)
+            if record is None:
+                return
+            record.state = "failed"
+            record.completed_at = completed_at
+            record.error = error
+            record.result_payload = None
+
+    def reconcile(self, call_id: str, tool_name: str, arguments: Any) -> Reconciliation:
+        key = canonical_call_key(tool_name, arguments)
+        rec = self.lookup(call_id)
+        if rec is None:
+            return Reconciliation(verdict=Verdict.FRESH)
+        if rec.canonical_key != key:
+            raise ToolCallIdentityError(
+                call_id,
+                recorded_key=rec.canonical_key,
+                incoming_key=key,
+                changed_fields=diff_canonical_fields(rec.arguments, arguments),
+            )
+        if rec.state == "completed" and rec.result_payload is not None:
+            return Reconciliation(
+                verdict=Verdict.REPLAY_SKIP,
+                record=rec,
+                replay_result=rec.result_payload,
+            )
+        if rec.state == "failed":
+            return Reconciliation(verdict=Verdict.FRESH, record=rec)
+        return Reconciliation(verdict=Verdict.AMBIGUOUS, record=rec)
+
+    def reconcile_safe(
+        self, call_id: str, tool_name: str, arguments: Any
+    ) -> Reconciliation:
+        """Like reconcile() but returns IDENTITY_CONFLICT instead of raising."""
+        try:
+            return self.reconcile(call_id, tool_name, arguments)
+        except ToolCallIdentityError:
+            return Reconciliation(
+                verdict=Verdict.IDENTITY_CONFLICT,
+                record=self.lookup(call_id),
+            )
+
+    def _store_result(self, result: str) -> tuple[str | None, str]:
+        text = str(result)
+        digest = _digest(text)
+        encoded = text.encode("utf-8")
+        if len(encoded) > self.max_inline_result_bytes:
+            return None, digest
+        return text, digest
+
+    def _append(self, payload: dict[str, Any]) -> None:
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+        with self._lock:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            if self._fh is None:
+                self._fh = open(self._path, "a", encoding="utf-8")
+            self._fh.write(line + "\n")
+            self._fh.flush()
+            os.fsync(self._fh.fileno())
+
+    def _replay_existing(self) -> None:
+        if not self._path.exists():
+            return
+        raw = self._path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return
+        parsed_any = False
+        usable = False
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("skipping corrupt ledger line session=%s", self.session_id)
+                continue
+            parsed_any = True
+            if not isinstance(data, dict):
+                continue
+            version = int(data.get("v", 1) or 1)
+            if version > 1:
+                logger.warning(
+                    "skipping ledger line with schema v=%s session=%s",
+                    version,
+                    self.session_id,
+                )
+                continue
+            if self._apply_line(data):
+                usable = True
+        if not parsed_any and raw.strip():
+            raise LedgerCorruptError(
+                f"ledger file is unparseable: {self._path}"
+            )
+        _ = usable
+
+    def _apply_line(self, data: dict[str, Any]) -> bool:
+        op = str(data.get("op", "") or "")
+        call_id = str(data.get("call_id", "") or "")
+        if not call_id:
+            return False
+        if op == "dispatch":
+            self._records[call_id] = CallRecord(
+                call_id=call_id,
+                canonical_key=str(data.get("canonical_key", "") or ""),
+                tool_name=str(data.get("tool_name", "") or ""),
+                state="dispatched",
+                dispatched_at=float(data.get("dispatched_at", data.get("ts", 0.0)) or 0.0),
+                replay_safety=str(data.get("replay_safety", "unknown") or "unknown"),
+                arguments=data.get("arguments"),
+            )
+            return True
+        record = self._records.get(call_id)
+        if record is None:
+            return False
+        if op == "result":
+            record.state = "completed"
+            record.completed_at = float(
+                data.get("completed_at", data.get("ts", 0.0)) or 0.0
+            )
+            record.result_digest = (
+                str(data["result_digest"]) if data.get("result_digest") else None
+            )
+            payload = data.get("result_payload")
+            record.result_payload = str(payload) if payload is not None else None
+            record.error = None
+            return True
+        if op == "failure":
+            record.state = "failed"
+            record.completed_at = float(
+                data.get("completed_at", data.get("ts", 0.0)) or 0.0
+            )
+            record.error = str(data.get("error", "") or "")
+            record.result_payload = None
+            return True
+        return False

--- a/agenticx/reliability/errors.py
+++ b/agenticx/reliability/errors.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Reliability kernel exceptions.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+
+class ReliabilityError(Exception):
+    """Base class for reliability-kernel failures."""
+
+
+class ToolCallIdentityError(ReliabilityError):
+    """Same ``call_id`` reappeared with a different canonical payload.
+
+    This is never recoverable by retrying: the model either fabricated an id
+    or the transport corrupted the call. Fail loudly instead of guessing which
+    payload was intended.
+    """
+
+    def __init__(
+        self,
+        call_id: str,
+        *,
+        recorded_key: str,
+        incoming_key: str,
+        changed_fields: tuple[str, ...] = (),
+    ) -> None:
+        self.call_id = call_id
+        self.recorded_key = recorded_key
+        self.incoming_key = incoming_key
+        self.changed_fields = changed_fields
+        fields = ", ".join(changed_fields) if changed_fields else "<unknown>"
+        super().__init__(
+            f"tool call id {call_id!r} reused with different arguments: "
+            f"recorded key {recorded_key[:16]}, incoming key {incoming_key[:16]}, "
+            f"changed fields: {fields}"
+        )
+
+
+class LedgerCorruptError(ReliabilityError):
+    """Ledger file exists but cannot be parsed into a usable state."""

--- a/agenticx/reliability/replay_policy.py
+++ b/agenticx/reliability/replay_policy.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Layered vetoes for whether an interrupted tool call may re-run.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from agenticx.reliability.call_ledger import Verdict
+
+ReplayAction = Literal["replay", "skip_use_recorded", "mark_unknown", "abort"]
+
+_SOFT_VETOES = {
+    "external_write": "external_side_effect",
+    "unknown": "unknown_side_effect",
+    "local_write": "local_write_ambiguous",
+}
+
+
+@dataclass(frozen=True)
+class ReplayRequest:
+    """Everything needed to decide whether one interrupted call may re-run."""
+
+    call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    ledger_verdict: Verdict
+    effect_class: str
+    output_already_emitted: bool = False
+    request_is_streaming: bool = False
+    approve_unsafe_replay: bool = False
+
+
+@dataclass(frozen=True)
+class ReplayDecision:
+    action: ReplayAction
+    veto: str | None
+    reason: str
+    approved_override: bool = False
+
+
+def _ignore_approval(base: str, approved: bool) -> str:
+    if approved:
+        return f"授权已忽略，因为 {base}"
+    return base
+
+
+def decide_replay(req: ReplayRequest) -> ReplayDecision:
+    """Return a layered veto decision. Earlier rows short-circuit."""
+    tool = req.tool_name
+
+    if req.ledger_verdict is Verdict.IDENTITY_CONFLICT:
+        base = (
+            f"工具 {tool} 的调用 {req.call_id} 参数与账本记录不一致，无法安全恢复"
+        )
+        return ReplayDecision(
+            action="abort",
+            veto="identity_conflict",
+            reason=_ignore_approval(base, req.approve_unsafe_replay),
+        )
+
+    if req.output_already_emitted:
+        return ReplayDecision(
+            action="mark_unknown",
+            veto="output_already_emitted",
+            reason=f"本轮输出已发给用户，不能重跑 {tool}（授权已忽略）",
+        )
+
+    if (
+        req.request_is_streaming
+        and not req.output_already_emitted
+        and req.ledger_verdict is Verdict.AMBIGUOUS
+    ):
+        base = f"本轮为流式请求且 {tool} 结果未知，不能重跑"
+        return ReplayDecision(
+            action="mark_unknown",
+            veto="streaming_request",
+            reason=_ignore_approval(base, req.approve_unsafe_replay),
+        )
+
+    if req.ledger_verdict is Verdict.REPLAY_SKIP:
+        return ReplayDecision(
+            action="skip_use_recorded",
+            veto=None,
+            reason=f"{tool} 已在中断前完成，复用已记录结果",
+        )
+
+    # FRESH means record_dispatch never fsynced — no side effect happened.
+    if req.ledger_verdict is Verdict.FRESH:
+        return ReplayDecision(
+            action="replay",
+            veto=None,
+            reason=f"{tool} 未成功派发，可安全重跑",
+        )
+
+    if req.effect_class in {"none", "read"}:
+        return ReplayDecision(
+            action="replay",
+            veto=None,
+            reason=f"{tool} 为只读操作，可安全重跑",
+        )
+
+    veto = _SOFT_VETOES.get(req.effect_class, "unknown_side_effect")
+    if req.approve_unsafe_replay:
+        return ReplayDecision(
+            action="replay",
+            veto=veto,
+            reason=f"调用方显式授权重放 {tool}（原否决：{veto}）",
+            approved_override=True,
+        )
+
+    if veto == "external_side_effect":
+        reason = f"{tool} 会产生外部副作用且执行结果未知，已跳过重跑"
+    elif veto == "unknown_side_effect":
+        reason = f"{tool} 的副作用未知（未声明 effect_class），保守跳过重跑"
+    else:
+        reason = f"{tool} 会写入本地且执行结果未知，已跳过重跑"
+    return ReplayDecision(action="mark_unknown", veto=veto, reason=reason)

--- a/agenticx/reliability/run_state.py
+++ b/agenticx/reliability/run_state.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Serializable RunState for an in-flight ReActAgent run.
+
+Unlike ``agenticx.runtime.checkpoint.AgentCheckpoint`` this type has no
+Studio dependency. Write failures raise; they are never swallowed.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from agenticx.utils.agx_home import agx_home
+from agenticx.utils.atomic_writer import atomic_write_json
+
+RUN_STATE_SCHEMA_VERSION = 1
+_PHASES = frozenset({"before_llm", "tools_dispatched", "completed", "interrupted"})
+
+
+def _validate_session_id(session_id: str) -> str:
+    value = str(session_id or "").strip()
+    if (
+        not value
+        or value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+    ):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    return value
+
+
+@dataclass
+class PendingCall:
+    call_id: str
+    tool_name: str
+    arguments: dict[str, Any]
+    canonical_key: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "PendingCall":
+        return cls(
+            call_id=str(raw.get("call_id", "") or ""),
+            tool_name=str(raw.get("tool_name", "") or ""),
+            arguments=dict(raw.get("arguments") or {}),
+            canonical_key=str(raw.get("canonical_key", "") or ""),
+        )
+
+
+@dataclass
+class RunState:
+    """Serializable snapshot of an in-flight ReActAgent run."""
+
+    run_id: str
+    session_id: str
+    schema_version: int = RUN_STATE_SCHEMA_VERSION
+    query: str = ""
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    iteration: int = 0
+    phase: Literal["before_llm", "tools_dispatched", "completed", "interrupted"] = (
+        "before_llm"
+    )
+    pending_calls: list[PendingCall] = field(default_factory=list)
+    created_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["pending_calls"] = [pc.to_dict() for pc in self.pending_calls]
+        return payload
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "RunState":
+        pending = [
+            PendingCall.from_dict(item)
+            for item in (raw.get("pending_calls") or [])
+            if isinstance(item, dict)
+        ]
+        phase = str(raw.get("phase", "before_llm") or "before_llm")
+        if phase not in _PHASES:
+            phase = "before_llm"
+        return cls(
+            run_id=str(raw.get("run_id", "") or ""),
+            session_id=str(raw.get("session_id", "") or ""),
+            schema_version=int(
+                raw.get("schema_version", RUN_STATE_SCHEMA_VERSION)
+                or RUN_STATE_SCHEMA_VERSION
+            ),
+            query=str(raw.get("query", "") or ""),
+            messages=list(raw.get("messages") or []),
+            iteration=int(raw.get("iteration", 0) or 0),
+            phase=phase,  # type: ignore[arg-type]
+            pending_calls=pending,
+            created_at=float(raw.get("created_at", 0.0) or 0.0),
+            updated_at=float(raw.get("updated_at", 0.0) or 0.0),
+        )
+
+
+class RunStateStore:
+    """File-backed RunState persistence (atomic replace, fail-closed)."""
+
+    def __init__(self, session_id: str, *, root: str | Path | None = None) -> None:
+        self.session_id = _validate_session_id(session_id)
+        parent = Path(root) if root is not None else agx_home() / "sessions"
+        self._dir = parent / self.session_id
+        self._path = self._dir / "run_state.json"
+
+    def save(self, state: RunState) -> None:
+        """Atomically persist. RAISES on failure — never swallow.
+
+        Unlike ``agenticx.runtime.checkpoint.CheckpointStore.save``, failures
+        are not logged-and-ignored: a durability kernel that cannot write
+        must not pretend the run is recoverable.
+        """
+        now = time.time()
+        if not state.created_at:
+            state.created_at = now
+        state.updated_at = now
+        self._dir.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(self._path, state.to_dict())
+
+    def load(self) -> RunState | None:
+        if not self._path.exists():
+            return None
+        data = json.loads(self._path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(f"invalid run state at {self._path}")
+        version = int(data.get("schema_version", 1) or 1)
+        if version > RUN_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported run state schema_version={version} "
+                f"(max {RUN_STATE_SCHEMA_VERSION})"
+            )
+        return RunState.from_dict(data)
+
+    def clear(self) -> None:
+        if self._path.exists():
+            self._path.unlink()

--- a/agenticx/runtime/checkpoint.py
+++ b/agenticx/runtime/checkpoint.py
@@ -59,18 +59,22 @@ class AgentCheckpoint(BaseModel):
 class CheckpointStore:
     """Synchronous checkpoint persistence over the session storage facade.
 
-    Write failures are logged and swallowed (same tolerance as the existing
-    mid-turn persist path); a missing/corrupt state reads as ``None``.
+    ``save()`` returns True on success and False on failure. Failures are
+    counted on ``save_failures`` and logged (first failure at error, later
+    ones at warning) but never raised — this path is best-effort, not the
+    primary persist-or-abort gate. A missing/corrupt state still reads as
+    ``None``.
     """
 
     def __init__(self, storage: SyncStorageFacade | None = None) -> None:
         self._storage = storage or get_sync_storage()
+        self.save_failures = 0
 
     @staticmethod
     def new_turn_id() -> str:
         return uuid.uuid4().hex
 
-    def save(self, checkpoint: AgentCheckpoint) -> None:
+    def save(self, checkpoint: AgentCheckpoint) -> bool:
         try:
             now = time.time()
             checkpoint.updated_at = now
@@ -80,12 +84,17 @@ class CheckpointStore:
                 checkpoint.session_id,
                 {"checkpoint": checkpoint.model_dump()},
             )
-        except Exception:
-            logger.warning(
-                "checkpoint save failed session=%s",
+            return True
+        except Exception as exc:
+            self.save_failures += 1
+            log = logger.error if self.save_failures == 1 else logger.warning
+            log(
+                "checkpoint save failed session=%s error=%s",
                 checkpoint.session_id,
+                type(exc).__name__,
                 exc_info=True,
             )
+            return False
 
     def load(self, session_id: str) -> Optional[AgentCheckpoint]:
         try:

--- a/agenticx/runtime/harden_flags.py
+++ b/agenticx/runtime/harden_flags.py
@@ -90,9 +90,53 @@ def interrupted_closers_enabled() -> bool:
     return _resolve_bool("AGX_INTERRUPTED_CLOSERS", "runtime.interrupted_closers", True)
 
 
+RELIABILITY_POSTURES = ("strict", "legacy")
+
+
+def _config_str(key: str) -> Optional[str]:
+    try:
+        from agenticx.cli.config_manager import ConfigManager
+
+        cfg = ConfigManager.get_value(key)
+        if isinstance(cfg, str) and cfg.strip():
+            return cfg.strip().lower()
+    except Exception:
+        pass
+    return None
+
+
+def reliability_posture() -> str:
+    """``AGX_RELIABILITY_POSTURE`` / ``reliability.posture``. Default ``"strict"``.
+
+    ``strict``  — durability failures abort the current turn and surface to the
+                  user; this is the posture the reliability benchmark measures.
+    ``legacy``  — pre-2026-09 behaviour: durability failures are logged and the
+                  run continues. Kept as an explicit escape hatch, not a default.
+
+    An unrecognised value falls back to ``"strict"`` (fail-closed on config
+    typos too — a misspelled posture must not silently weaken durability).
+    """
+    raw = os.environ.get("AGX_RELIABILITY_POSTURE", "").strip().lower()
+    if raw not in RELIABILITY_POSTURES:
+        raw = _config_str("reliability.posture") or ""
+    if raw not in RELIABILITY_POSTURES:
+        return "strict"
+    return raw
+
+
 def persist_fail_closed_enabled() -> bool:
-    """``AGX_PERSIST_FAIL_CLOSED`` / ``runtime.persist_fail_closed``. Default False."""
-    return _resolve_bool("AGX_PERSIST_FAIL_CLOSED", "runtime.persist_fail_closed", False)
+    """``AGX_PERSIST_FAIL_CLOSED`` / ``runtime.persist_fail_closed``.
+
+    Default follows ``reliability_posture()``: True under ``strict`` (the new
+    default), False under ``legacy``. The dedicated env var / config key still
+    wins when set, so an operator can pin this single behaviour without moving
+    the whole posture.
+    """
+    return _resolve_bool(
+        "AGX_PERSIST_FAIL_CLOSED",
+        "runtime.persist_fail_closed",
+        reliability_posture() == "strict",
+    )
 
 
 def fresh_round_loop_enabled() -> bool:

--- a/agenticx/runtime/replay_ledger/__init__.py
+++ b/agenticx/runtime/replay_ledger/__init__.py
@@ -14,7 +14,15 @@ from agenticx.runtime.replay_ledger.contracts import (
     RunEvent,
     WorkspaceSnapshotRef,
 )
-from agenticx.runtime.replay_ledger.store import ReplayLedgerStore
+
+
+def __getattr__(name: str):
+    if name == "ReplayLedgerStore":
+        from agenticx.runtime.replay_ledger.store import ReplayLedgerStore
+
+        return ReplayLedgerStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "COMPLETENESS_VALUES",

--- a/agenticx/tools/base.py
+++ b/agenticx/tools/base.py
@@ -46,7 +46,42 @@ class BaseTool(ABC):
     - 统一的错误处理和回调机制
     - 多租户支持
     """
-    
+
+    #: Optional declaration of this tool's side-effect class, used by
+    #: ``agenticx.reliability.replay_policy`` to decide whether a call may be
+    #: re-executed after a crash. ``None`` means "no declaration" and falls
+    #: back to name/command based classification, which itself defaults to
+    #: ``"unknown"`` (fail-closed). Valid values: the members of
+    #: ``agenticx.runtime.replay_ledger.contracts.EFFECT_CLASSES``.
+    effect_class: Optional[str] = None
+
+    def resolve_effect_class(self, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Return the effective side-effect class for one invocation.
+
+        Resolution order (first hit wins):
+          1. this instance's / subclass's ``effect_class`` declaration
+          2. name & command based classification (``classify_tool_effect``)
+          3. ``"unknown"`` — never assume safety for an unrecognised tool
+        """
+        declared = self.effect_class
+        if declared is not None:
+            # Function-level import: ``agenticx.tools.base`` is a widely
+            # imported leaf. A module-level ``agenticx.runtime.*`` import
+            # would invert the tools → runtime dependency.
+            from agenticx.runtime.replay_ledger.contracts import EFFECT_CLASSES
+
+            if declared not in EFFECT_CLASSES:
+                raise ValueError(
+                    f"invalid effect_class {declared!r} for tool "
+                    f"{getattr(self, 'name', type(self).__name__)}"
+                )
+            return declared
+        from agenticx.runtime.replay_ledger.effects import classify_tool_effect
+
+        name = getattr(self, "name", None) or self.__class__.__name__
+        classified = classify_tool_effect(name, arguments or {})
+        return classified if classified else "unknown"
+
     def __init__(
         self,
         name: Optional[str] = None,

--- a/conclusions/agents_module_conclusion.md
+++ b/conclusions/agents_module_conclusion.md
@@ -31,13 +31,15 @@ agenticx/agents/
 **关键组件**：
 - `ReActAgent` 类：核心循环
   - `astream(query, history)`：运行 FC 循环并产出类型化 `AgentEvent` 事件流（作为唯一事实来源 NFR-4）
+  - `aresume(state)`：从 `RunState` / `RunStateStore` 崩溃续跑（依赖 `agenticx.reliability`）
   - `arun(query, history)`：聚合 `astream` 为 `ReActResult`
   - `run(query, history)`：同步便捷封装，在已有事件循环中调用时明确报错引导改用 `arun`
   - `add_tool()` / `stop()`：动态注册工具 / 请求优雅中断
   - 工具调度：`asyncio.gather` + `run_in_executor` 并行执行同一轮的多个 `tool_calls`（避免 `BaseTool._is_running` 串行化）
   - 可选注入：`compactor`（上下文压缩）、`offloader`（超阈值工具结果落盘并回填占位符，依赖 `core.offload`）、`loop_detector`（`runtime.loop_detector.LoopDetector`，循环检测后注入 nudge system 消息）
 - `ReActResult` 数据类：`success` / `output` / `error` / `messages`（历史进出）/ `iterations` / `events`
-- 取消语义：透传 `asyncio.CancelledError`，并在事件流中产出不可恢复 `ErrorEvent`
+- 取消语义：透传 `asyncio.CancelledError`，并在事件流中产出 `InterruptedEvent`（可续跑）
+- 可选耐久：`run_store` / `call_ledger` 为 keyword-only，默认关闭时行为与无持久化时一致
 
 **业务逻辑**：作为对外 SDK 的「一等公民」ReAct 原语，覆盖原生工具调用、流式可观测、循环检测、上下文压缩/卸载等能力，且与产品运行时解耦，便于在 FastAPI SSE、嵌入式集成等场景复用。
 
@@ -45,9 +47,9 @@ agenticx/agents/
 
 ### AgentEvent 事件类型 (agent_events.py, 新增)
 
-**文件功能**：为规范 ReActAgent 流式输出定义最小化（≤6 类）的类型化事件联合，服务于 FastAPI SSE、可观测性与 `arun`/`astream` 一致性。
+**文件功能**：为规范 ReActAgent 流式输出定义类型化事件联合（7 类），服务于 FastAPI SSE、可观测性与 `arun`/`astream`/`aresume` 一致性。
 
-**关键组件**：`TokenEvent`（文本增量）、`ReasoningEvent`（一次推理/模型调用迭代起点）、`ToolCallEvent`（模型请求工具调用）、`ToolResultEvent`（工具执行结果）、`FinalEvent`（终态：最终产出 + 消息历史 + 迭代数）、`ErrorEvent`（可恢复/终态错误）；`AgentEvent = Union[...]`。
+**关键组件**：`TokenEvent`（文本增量）、`ReasoningEvent`（一次推理/模型调用迭代起点）、`ToolCallEvent`（模型请求工具调用）、`ToolResultEvent`（工具执行结果）、`FinalEvent`（终态：最终产出 + 消息历史 + 迭代数）、`ErrorEvent`（可恢复/终态错误）、`InterruptedEvent`（中断且可续跑）；`AgentEvent = Union[...]`。
 
 **依赖关系**：被 `react_agent_async.ReActAgent.astream` 消费。
 

--- a/docs/guides/reliability-posture.md
+++ b/docs/guides/reliability-posture.md
@@ -1,0 +1,71 @@
+# 可靠性姿态（reliability.posture）
+
+AgenticX 用 `reliability.posture` 决定磁盘写失败时是中止本轮，还是记日志后带病继续。
+
+## 两种姿态
+
+| | `strict`（默认） | `legacy` |
+|---|---|---|
+| 持久化失败 | 中止本轮，错误对调用方可见 | 记日志，运行继续 |
+| `persist_fail_closed_enabled()` | 默认 True | 默认 False |
+| `CheckpointStore.save` | 返回 `False` 并累计 `save_failures`；首次失败打 error 日志 | 同样可观测，但不因此改变主循环默认 |
+| 适用 | 新部署、关心重复副作用 | 需要与 2026-09 之前行为对齐的回滚 |
+
+`strict` 下 `CheckpointStore.save` **仍然不抛异常**。它是 best-effort 补充检查点，主持久化门禁仍是 `_persist_or_abort()`。
+
+## Subplan 04 对照数字
+
+用 `agenticx-reliability-v1` 在同一机器上各跑一遍。该基准驱动的是 SDK `ReActAgent` + `RunStateStore`，不经过 `CheckpointStore` / `_persist_or_abort`，所以两姿态数字相同。放行条件全部满足，因此默认切到 `strict`。
+
+| 指标 | `legacy` | `strict` | 方向 |
+|---|---|---|---|
+| duplicate_side_effect_rate | 0.0000 | 0.0000 | 越低越好 |
+| crash_recovery_success_rate | 1.0000 | 1.0000 | 越高越好 |
+| history_consistency_rate | 1.0000 | 1.0000 | 硬要求 1.0 |
+| error_diagnosability_rate | 1.0000 | 1.0000 | 越高越好 |
+
+复现命令：
+
+```bash
+python -c "
+from pathlib import Path
+from agenticx.evaluation import EvalSet, ReliabilityRunner
+es = EvalSet.from_file('agenticx/evaluation/benchmarks/reliability_v1.json')
+import tempfile
+with tempfile.TemporaryDirectory() as d:
+    print(ReliabilityRunner(root=Path(d)).run(es).to_report())
+"
+```
+
+## 回滚
+
+整体退回旧姿态：
+
+```bash
+export AGX_RELIABILITY_POSTURE=legacy
+```
+
+或在 `~/.agenticx/config.yaml`：
+
+```yaml
+reliability:
+  posture: legacy
+```
+
+只回滚「持久化失败是否中止本轮」这一项：
+
+```bash
+export AGX_PERSIST_FAIL_CLOSED=0
+```
+
+优先级：`AGX_PERSIST_FAIL_CLOSED` > `runtime.persist_fail_closed` > `AGX_RELIABILITY_POSTURE` > `reliability.posture` > `strict`。拼写错误的 posture 回落到 `strict`，不会悄悄变成 `legacy`。
+
+## 方法论限制
+
+本对照用的是**进程内模拟崩溃**（在指定边界抛不可捕获异常并丢弃内存态，从磁盘状态重建），不是真实进程 kill，也不覆盖 OS 级页缓存丢失、磁盘损坏等物理故障。
+
+## 验证记录
+
+- `pytest tests/test_reliability_posture.py tests/test_smoke_persist_fail_closed.py`：15 passed。
+- `agx serve --host 127.0.0.1 --port 18801` 冷启动后，`curl --noproxy '*'` 打 `/api/session`、`/api/avatars`、`/api/sessions` 均返回 200。
+- Desktop 人工 3 轮对话：本阶段未启动 Near GUI。`strict` 在磁盘健康时应完全不可感知；若分身/历史/工作区同时空态，优先查 `agx serve` 是否存活。

--- a/tests/test_react_agent_resume.py
+++ b/tests/test_react_agent_resume.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Tests for ReActAgent durability and aresume.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import pytest
+
+from agenticx.agents.agent_events import (
+    FinalEvent,
+    InterruptedEvent,
+    ToolCallEvent,
+)
+from agenticx.agents.react_agent_async import ReActAgent
+from agenticx.llms.base import BaseLLMProvider
+from agenticx.llms.response import LLMChoice, LLMResponse, TokenUsage
+from agenticx.reliability.call_identity import canonical_call_key
+from agenticx.reliability.call_ledger import CallLedger
+from agenticx.reliability.errors import ToolCallIdentityError
+from agenticx.reliability.run_state import PendingCall, RunState, RunStateStore
+from agenticx.runtime.interrupted_closers import (
+    KIND_OUTCOME_UNKNOWN,
+    OUTCOME_UNKNOWN_CONTENT,
+)
+from agenticx.tools.base import BaseTool
+
+
+class MockFCProvider(BaseLLMProvider):
+    model: str = "mock-fc"
+
+    def __init__(self, responses: List[LLMResponse], **data: Any):
+        super().__init__(**data)
+        object.__setattr__(self, "_responses", list(responses))
+        object.__setattr__(self, "_calls", 0)
+        object.__setattr__(self, "_raise_on", data.pop("_raise_on", None) if False else None)
+
+    @property
+    def call_count(self) -> int:
+        return object.__getattribute__(self, "_calls")
+
+    def _pop(self) -> LLMResponse:
+        idx = object.__getattribute__(self, "_calls")
+        responses = object.__getattribute__(self, "_responses")
+        object.__setattr__(self, "_calls", idx + 1)
+        if idx < len(responses):
+            return responses[idx]
+        return LLMResponse(
+            id="fallback",
+            model_name=self.model,
+            created=0,
+            content="fallback answer",
+            choices=[LLMChoice(index=0, content="fallback answer")],
+            token_usage=TokenUsage(),
+        )
+
+    async def ainvoke(
+        self,
+        prompt: Union[str, List[Dict[str, Any]]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        return self._pop()
+
+    def invoke(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+    def stream(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def astream(self, prompt, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+
+class BoomOnInvoke(MockFCProvider):
+    async def ainvoke(self, prompt, tools=None, **kwargs):
+        raise RuntimeError("llm down")
+
+
+class CounterTool(BaseTool):
+    """Increments a shared counter; the count IS the side effect under test."""
+
+    def __init__(self) -> None:
+        super().__init__(name="bump", description="Bump a counter.")
+        self.calls: List[str] = []
+
+    def _run(self, **kwargs):
+        key = str(kwargs.get("key", "") or "")
+        self.calls.append(key)
+        return f"count={len(self.calls)}"
+
+
+class InterruptTool(BaseTool):
+    def __init__(self) -> None:
+        super().__init__(name="bump", description="Raise during execution.")
+        self.calls: List[str] = []
+
+    def _run(self, **kwargs):
+        self.calls.append(str(kwargs.get("key", "") or ""))
+        raise KeyboardInterrupt("kill-before-result")
+
+
+def _tc(name: str, args: dict, tc_id: str = "tc1") -> Dict[str, Any]:
+    return {
+        "id": tc_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args)},
+    }
+
+
+def _final(text: str = "done") -> LLMResponse:
+    return LLMResponse(
+        id="final",
+        model_name="mock",
+        created=0,
+        content=text,
+        choices=[LLMChoice(index=0, content=text)],
+        token_usage=TokenUsage(),
+    )
+
+
+def _tool_round(*calls: Dict[str, Any]) -> LLMResponse:
+    return LLMResponse(
+        id="tools",
+        model_name="mock",
+        created=0,
+        content="",
+        choices=[],
+        token_usage=TokenUsage(),
+        tool_calls=list(calls),
+    )
+
+
+def _collect(agent: ReActAgent, query: str = "go"):
+    async def _run():
+        events = []
+        async for event in agent.astream(query):
+            events.append(event)
+        return events
+
+    return asyncio.run(_run())
+
+
+def test_no_store_behaves_identically(tmp_path: Path) -> None:
+    llm = MockFCProvider([_final("ok")])
+    events = _collect(ReActAgent(llm=llm, tools=[], system_prompt="t"), "hi")
+    assert [type(e).__name__ for e in events] == ["ReasoningEvent", "FinalEvent"]
+    assert not any(tmp_path.rglob("run_state.json"))
+    assert not any(tmp_path.rglob("call_ledger.jsonl"))
+
+
+def test_state_written_before_llm(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+    agent = ReActAgent(
+        llm=BoomOnInvoke([]),
+        tools=[],
+        session_id="sess",
+        run_store=store,
+    )
+    with pytest.raises(RuntimeError, match="llm down"):
+        _collect(agent, "hi")
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.phase == "before_llm"
+
+
+def test_state_written_before_tools(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+    llm = MockFCProvider([_tool_round(_tc("bump", {"key": "a"}, "c1"))])
+    agent = ReActAgent(
+        llm=llm,
+        tools=[InterruptTool()],
+        session_id="sess",
+        run_store=store,
+        call_ledger=CallLedger("sess", root=tmp_path),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        _collect(agent, "hi")
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.phase == "tools_dispatched"
+    assert len(loaded.pending_calls) == 1
+    assert loaded.pending_calls[0].canonical_key
+
+
+def test_resume_skips_completed_tool(tmp_path: Path) -> None:
+    counter = CounterTool()
+    ledger = CallLedger("sess", root=tmp_path)
+    ledger.record_dispatch("c1", "bump", {"key": "a"})
+    ledger.record_result("c1", "count=1")
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            query="hi",
+            messages=[
+                {"role": "system", "content": "t"},
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [_tc("bump", {"key": "a"}, "c1")],
+                },
+            ],
+            iteration=1,
+            phase="tools_dispatched",
+            pending_calls=[
+                PendingCall(
+                    "c1",
+                    "bump",
+                    {"key": "a"},
+                    canonical_call_key("bump", {"key": "a"}),
+                )
+            ],
+        )
+    )
+    llm = MockFCProvider([_final("done")])
+    agent = ReActAgent(
+        llm=llm,
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+        run_id="r1",
+    )
+
+    async def _run():
+        return [event async for event in agent.aresume()]
+
+    events = asyncio.run(_run())
+    assert counter.calls == []
+    assert any(
+        m.get("role") == "tool" and m.get("content") == "count=1"
+        for m in events[-1].messages  # type: ignore[attr-defined]
+    )
+
+
+def test_resume_reruns_fresh_tool(tmp_path: Path) -> None:
+    counter = CounterTool()
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            query="hi",
+            messages=[
+                {"role": "system", "content": "t"},
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [_tc("bump", {"key": "a"}, "c1")],
+                },
+            ],
+            iteration=1,
+            phase="tools_dispatched",
+            pending_calls=[
+                PendingCall(
+                    "c1",
+                    "bump",
+                    {"key": "a"},
+                    canonical_call_key("bump", {"key": "a"}),
+                )
+            ],
+        )
+    )
+    llm = MockFCProvider([_final("done")])
+    agent = ReActAgent(
+        llm=llm,
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=CallLedger("sess", root=tmp_path),
+        run_id="r1",
+    )
+    asyncio.run(_consume_resume(agent))
+    assert counter.calls == ["a"]
+
+
+def test_resume_marks_ambiguous(tmp_path: Path) -> None:
+    counter = CounterTool()
+    ledger = CallLedger("sess", root=tmp_path)
+    ledger.record_dispatch("c1", "bump", {"key": "a"})
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            query="hi",
+            messages=[
+                {"role": "system", "content": "t"},
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [_tc("bump", {"key": "a"}, "c1")],
+                },
+            ],
+            iteration=1,
+            phase="tools_dispatched",
+            pending_calls=[
+                PendingCall(
+                    "c1",
+                    "bump",
+                    {"key": "a"},
+                    canonical_call_key("bump", {"key": "a"}),
+                )
+            ],
+        )
+    )
+    agent = ReActAgent(
+        llm=MockFCProvider([_final("done")]),
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+        run_id="r1",
+    )
+    events = asyncio.run(_consume_resume(agent))
+    assert counter.calls == []
+    final = events[-1]
+    assert isinstance(final, FinalEvent)
+    tool_rows = [m for m in final.messages if m.get("role") == "tool"]
+    assert tool_rows
+    assert OUTCOME_UNKNOWN_CONTENT in tool_rows[0]["content"]
+    assert tool_rows[0]["metadata"]["kind"] == KIND_OUTCOME_UNKNOWN
+
+
+def test_resume_identity_conflict_raises(tmp_path: Path) -> None:
+    ledger = CallLedger("sess", root=tmp_path)
+    ledger.record_dispatch("c1", "bump", {"key": "old"})
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            phase="tools_dispatched",
+            messages=[{"role": "user", "content": "hi"}],
+            pending_calls=[
+                PendingCall(
+                    "c1",
+                    "bump",
+                    {"key": "new"},
+                    canonical_call_key("bump", {"key": "new"}),
+                )
+            ],
+        )
+    )
+    agent = ReActAgent(
+        llm=MockFCProvider([]),
+        tools=[CounterTool()],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+        run_id="r1",
+    )
+    with pytest.raises(ToolCallIdentityError):
+        asyncio.run(_consume_resume(agent))
+
+
+def test_resume_completed_returns_final(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            phase="completed",
+            iteration=2,
+            messages=[
+                {"role": "assistant", "content": "already done"},
+            ],
+        )
+    )
+    llm = MockFCProvider([_final("should-not-run")])
+    agent = ReActAgent(
+        llm=llm,
+        tools=[],
+        session_id="sess",
+        run_store=store,
+        run_id="r1",
+    )
+    events = asyncio.run(_consume_resume(agent))
+    assert llm.call_count == 0
+    assert isinstance(events[0], FinalEvent)
+    assert events[0].success is True
+
+
+def test_final_clears_state(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+    agent = ReActAgent(
+        llm=MockFCProvider([_final("ok")]),
+        tools=[],
+        session_id="sess",
+        run_store=store,
+    )
+    _collect(agent, "hi")
+    assert store.load() is None
+
+
+def test_stop_yields_interrupted_event(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+    agent = ReActAgent(
+        llm=MockFCProvider([_final("ok")]),
+        tools=[],
+        session_id="sess",
+        run_store=store,
+    )
+    agent.stop()
+    events = _collect(agent, "hi")
+    interrupted = [e for e in events if isinstance(e, InterruptedEvent)]
+    assert interrupted
+    assert interrupted[0].reason == "user_stop"
+    assert interrupted[0].messages
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.phase == "interrupted"
+
+
+def test_cancel_persists_then_reraises(tmp_path: Path) -> None:
+    store = RunStateStore("sess", root=tmp_path)
+
+    class SlowLLM(MockFCProvider):
+        async def ainvoke(self, prompt, tools=None, **kwargs):
+            await asyncio.sleep(10)
+            return _final("late")
+
+    agent = ReActAgent(
+        llm=SlowLLM([]),
+        tools=[],
+        session_id="sess",
+        run_store=store,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(_consume_stream(agent))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_run())
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.phase == "interrupted"
+
+
+def test_stable_id_when_provider_omits_id(tmp_path: Path) -> None:
+    ledger = CallLedger("sess", root=tmp_path)
+    store = RunStateStore("sess", root=tmp_path)
+    llm = MockFCProvider(
+        [
+            _tool_round(_tc("bump", {"key": "a"}, "")),
+            _final("done"),
+        ]
+    )
+    counter = CounterTool()
+    agent = ReActAgent(
+        llm=llm,
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+    )
+    events = _collect(agent, "hi")
+    tool_events = [e for e in events if isinstance(e, ToolCallEvent)]
+    assert tool_events
+    call_id = tool_events[0].tool_call_id
+    assert call_id
+    final = events[-1]
+    assert isinstance(final, FinalEvent)
+    tool_rows = [m for m in final.messages if m.get("role") == "tool"]
+    assert tool_rows[0]["tool_call_id"] == call_id
+    assert ledger.lookup(call_id) is not None
+
+
+def test_end_to_end_no_duplicate_side_effect(tmp_path: Path) -> None:
+    counter = CounterTool()
+    ledger = CallLedger("sess", root=tmp_path)
+    store = RunStateStore("sess", root=tmp_path)
+    llm = MockFCProvider(
+        [
+            _tool_round(
+                _tc("bump", {"key": "a"}, "c1"),
+                _tc("bump", {"key": "b"}, "c2"),
+            ),
+            _final("done"),
+        ]
+    )
+
+    original = ledger.record_result
+    seen = {"n": 0}
+
+    def _record(call_id: str, result: str, *, success: bool = True) -> None:
+        original(call_id, result, success=success)
+        seen["n"] += 1
+        if seen["n"] >= 2:
+            raise KeyboardInterrupt("kill-after-second-result")
+
+    ledger.record_result = _record  # type: ignore[method-assign]
+    agent = ReActAgent(
+        llm=llm,
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        _collect(agent, "hi")
+    assert len(counter.calls) == 2
+
+    ledger.record_result = original  # type: ignore[method-assign]
+    resume_agent = ReActAgent(
+        llm=MockFCProvider([_final("done")]),
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=CallLedger.load("sess", root=tmp_path),
+    )
+    asyncio.run(_consume_resume(resume_agent))
+    assert counter.calls == ["a", "b"]
+
+
+def _dispatched_counter_setup(
+    tmp_path: Path,
+    counter: CounterTool,
+):
+    ledger = CallLedger("sess", root=tmp_path)
+    ledger.record_dispatch("c1", "bump", {"key": "a"})
+    store = RunStateStore("sess", root=tmp_path)
+    store.save(
+        RunState(
+            run_id="r1",
+            session_id="sess",
+            query="hi",
+            messages=[
+                {"role": "system", "content": "t"},
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [_tc("bump", {"key": "a"}, "c1")],
+                },
+            ],
+            iteration=1,
+            phase="tools_dispatched",
+            pending_calls=[
+                PendingCall(
+                    "c1",
+                    "bump",
+                    {"key": "a"},
+                    canonical_call_key("bump", {"key": "a"}),
+                )
+            ],
+        )
+    )
+    agent = ReActAgent(
+        llm=MockFCProvider([_final("done")]),
+        tools=[counter],
+        session_id="sess",
+        run_store=store,
+        call_ledger=ledger,
+        run_id="r1",
+    )
+    return agent
+
+
+def test_resume_external_write_not_replayed(tmp_path: Path) -> None:
+    counter = CounterTool()
+    counter.effect_class = "external_write"
+    agent = _dispatched_counter_setup(tmp_path, counter)
+    events = asyncio.run(_consume_resume(agent))
+    assert counter.calls == []
+    final = events[-1]
+    assert isinstance(final, FinalEvent)
+    tool_rows = [m for m in final.messages if m.get("role") == "tool"]
+    assert tool_rows
+    assert tool_rows[0]["metadata"]["veto"] == "external_side_effect"
+
+
+def test_resume_read_tool_replayed(tmp_path: Path) -> None:
+    counter = CounterTool()
+    counter.effect_class = "read"
+    agent = _dispatched_counter_setup(tmp_path, counter)
+    asyncio.run(_consume_resume(agent))
+    assert counter.calls == ["a"]
+
+
+def test_resume_with_approval_replays(tmp_path: Path) -> None:
+    counter = CounterTool()
+    counter.effect_class = "external_write"
+    agent = _dispatched_counter_setup(tmp_path, counter)
+    asyncio.run(_consume_resume(agent, approve_unsafe_replay=True))
+    assert counter.calls == ["a"]
+
+
+async def _consume_stream(agent: ReActAgent):
+    async for _ in agent.astream("hi"):
+        pass
+
+
+async def _consume_resume(agent: ReActAgent, **kwargs: Any):
+    return [event async for event in agent.aresume(**kwargs)]

--- a/tests/test_reliability_bench.py
+++ b/tests/test_reliability_bench.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for the in-process reliability fault-injection bench.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from agenticx.evaluation.evalset import EvalSet
+from agenticx.evaluation.fault_injection import (
+    CountingTool,
+    FaultInjector,
+    FaultKind,
+    FaultSpec,
+    SideEffectCounter,
+    _InjectedCrash,
+)
+from agenticx.evaluation.reliability_runner import (
+    ReliabilityCase,
+    ReliabilityRunner,
+    _is_diagnosable,
+    check_history_consistency,
+)
+
+BENCHMARK = (
+    Path(__file__).resolve().parents[1]
+    / "agenticx"
+    / "evaluation"
+    / "benchmarks"
+    / "reliability_v1.json"
+)
+
+
+def test_injector_fires_once() -> None:
+    injector = FaultInjector(FaultSpec(FaultKind.KILL_BEFORE_TOOL_RESULT))
+    hits = [
+        injector.should_fire(
+            boundary="before_tool_result", call_index=1, tool_name="bump"
+        )
+        for _ in range(5)
+    ]
+    assert hits == [True, False, False, False, False]
+    assert injector.fired is True
+
+
+def test_injector_respects_call_index() -> None:
+    injector = FaultInjector(
+        FaultSpec(FaultKind.KILL_BEFORE_TOOL_RESULT, at_call_index=2)
+    )
+    assert injector.should_fire(
+        boundary="before_tool_result", call_index=1, tool_name="bump"
+    ) is False
+    assert injector.should_fire(
+        boundary="before_tool_result", call_index=2, tool_name="bump"
+    ) is True
+
+
+def test_injector_respects_tool_name() -> None:
+    injector = FaultInjector(
+        FaultSpec(FaultKind.KILL_BEFORE_TOOL_RESULT, tool_name="bump")
+    )
+    assert injector.should_fire(
+        boundary="before_tool_result", call_index=1, tool_name="other"
+    ) is False
+    assert injector.should_fire(
+        boundary="before_tool_result", call_index=1, tool_name="bump"
+    ) is True
+
+
+def test_injected_crash_not_caught_by_except_exception() -> None:
+    try:
+        raise _InjectedCrash("boom")
+    except Exception:  # noqa: BLE001
+        pytest.fail("InjectedCrash must not be caught by except Exception")
+    except _InjectedCrash:
+        pass
+
+
+def test_counter_duplicate_count() -> None:
+    counter = SideEffectCounter()
+    counter.apply("a", {"n": 1})
+    counter.apply("a", {"n": 2})
+    counter.apply("a", {"n": 3})
+    assert counter.duplicate_count == 2
+    other = SideEffectCounter()
+    other.apply("a", {})
+    other.apply("b", {})
+    assert other.duplicate_count == 0
+
+
+def test_counter_read_not_counted() -> None:
+    counter = SideEffectCounter()
+    tool = CountingTool(counter, effect_class="read")
+    tool._run(key="a")
+    tool._run(key="a")
+    tool._run(key="a")
+    assert counter.duplicate_count == 0
+    assert len(counter.reads) == 3
+
+
+def test_reliability_case_roundtrip() -> None:
+    original = ReliabilityCase(
+        id="roundtrip",
+        query="go",
+        fault=FaultSpec(FaultKind.PERSIST_FAILURE, at_call_index=1, tool_name=None),
+        llm_script=[[{"final": "ok"}]],
+        tool_effect_class="read",
+        expected_total_effects=1,
+        expect_resume_success=False,
+        expect_error_diagnosable=True,
+    )
+    assert ReliabilityCase.from_eval_case(original.to_eval_case()) == original
+
+
+def test_benchmark_json_is_valid_evalset() -> None:
+    evalset = EvalSet.from_file(BENCHMARK)
+    assert evalset.name == "agenticx-reliability-v1"
+    assert len(evalset) >= 12
+
+
+def test_is_diagnosable_rejects_bare_token() -> None:
+    assert _is_diagnosable("'_type'", tool_name="bump") is False
+    assert _is_diagnosable("KeyError", tool_name="bump") is False
+
+
+def test_is_diagnosable_accepts_full_reason() -> None:
+    assert (
+        _is_diagnosable(
+            "bump 会产生外部副作用且执行结果未知，已跳过重跑",
+            tool_name="bump",
+        )
+        is True
+    )
+
+
+def test_history_check_detects_orphan_tool_row() -> None:
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "c1", "content": "orphan"},
+    ]
+    assert check_history_consistency(messages) is False
+
+
+def test_history_check_detects_duplicate_tool_row() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "bump"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "a"},
+        {"role": "tool", "tool_call_id": "c1", "content": "b"},
+    ]
+    assert check_history_consistency(messages) is False
+
+
+def test_history_check_accepts_valid() -> None:
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "c1", "function": {"name": "bump"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
+    assert check_history_consistency(messages) is True
+
+
+def _run_bench(tmp_path: Path):
+    evalset = EvalSet.from_file(BENCHMARK)
+    return ReliabilityRunner(root=tmp_path).run(evalset)
+
+
+def test_bench_runs_offline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BlockedSocket(socket.socket):
+        def connect(self, address):  # type: ignore[override]
+            raise RuntimeError("network disabled")
+
+        def connect_ex(self, address):  # type: ignore[override]
+            raise RuntimeError("network disabled")
+
+    monkeypatch.setattr("socket.socket", _BlockedSocket)
+    metrics = _run_bench(tmp_path)
+    assert metrics.total_cases >= 12
+
+
+def test_zero_duplicate_side_effects(tmp_path: Path) -> None:
+    assert _run_bench(tmp_path).duplicate_side_effect_rate == 0.0
+
+
+def test_full_crash_recovery(tmp_path: Path) -> None:
+    assert _run_bench(tmp_path).crash_recovery_success_rate == 1.0
+
+
+def test_full_history_consistency(tmp_path: Path) -> None:
+    assert _run_bench(tmp_path).history_consistency_rate == 1.0
+
+
+def test_full_error_diagnosability(tmp_path: Path) -> None:
+    assert _run_bench(tmp_path).error_diagnosability_rate == 1.0
+
+
+def test_metrics_report_contains_methodology(tmp_path: Path) -> None:
+    report = _run_bench(tmp_path).to_report()
+    assert "进程内模拟崩溃" in report
+
+
+def test_bench_is_deterministic(tmp_path: Path) -> None:
+    first = _run_bench(tmp_path / "a")
+    second = _run_bench(tmp_path / "b")
+    assert first.duplicate_side_effect_rate == second.duplicate_side_effect_rate
+    assert first.crash_recovery_success_rate == second.crash_recovery_success_rate
+    assert first.history_consistency_rate == second.history_consistency_rate
+    assert first.error_diagnosability_rate == second.error_diagnosability_rate
+    keys = (
+        "id",
+        "duplicates",
+        "resume_ok",
+        "history_ok",
+        "diagnosable",
+        "effects_total",
+    )
+    assert [{k: row[k] for k in keys} for row in first.per_case] == [
+        {k: row[k] for k in keys} for row in second.per_case
+    ]
+
+
+def test_bench_uses_tmp_path(tmp_path: Path) -> None:
+    home = Path.home() / ".agenticx"
+
+    def _files() -> set[str]:
+        if not home.exists():
+            return set()
+        return {str(path.relative_to(home)) for path in home.rglob("*") if path.is_file()}
+
+    before = _files()
+    _run_bench(tmp_path)
+    assert _files() == before

--- a/tests/test_reliability_call_identity.py
+++ b/tests/test_reliability_call_identity.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for tool-call canonical identity.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agenticx.reliability.call_identity import (
+    canonical_call_key,
+    canonical_payload,
+    diff_canonical_fields,
+    stable_call_id,
+)
+
+
+def test_key_stable_across_dict_order() -> None:
+    assert canonical_call_key("t", {"a": 1, "b": 2}) == canonical_call_key(
+        "t", {"b": 2, "a": 1}
+    )
+
+
+def test_key_differs_by_tool_name() -> None:
+    args = {"a": 1}
+    assert canonical_call_key("alpha", args) != canonical_call_key("beta", args)
+
+
+def test_int_and_float_differ() -> None:
+    assert canonical_call_key("t", {"n": 1}) != canonical_call_key("t", {"n": 1.0})
+
+
+def test_negative_zero_normalized() -> None:
+    assert canonical_call_key("t", {"n": -0.0}) == canonical_call_key("t", {"n": 0.0})
+
+
+def test_nan_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_payload({"n": float("nan")})
+
+
+def test_inf_rejected() -> None:
+    with pytest.raises(ValueError):
+        canonical_payload({"n": float("inf")})
+
+
+def test_unsupported_type_rejected() -> None:
+    with pytest.raises(TypeError, match="object"):
+        canonical_payload({"n": object()})
+
+
+def test_bool_not_int() -> None:
+    assert canonical_call_key("t", {"f": True}) != canonical_call_key("t", {"f": 1})
+
+
+def test_nested_normalized() -> None:
+    left = {"a": {"x": [1, {"z": 2}]}}
+    right = {"a": {"x": [1, {"z": 2}]}}
+    assert canonical_call_key("t", left) == canonical_call_key("t", right)
+
+
+def test_tuple_equals_list() -> None:
+    assert canonical_call_key("t", {"a": (1, 2)}) == canonical_call_key(
+        "t", {"a": [1, 2]}
+    )
+
+
+def test_unicode_stable() -> None:
+    payload = canonical_payload({"名": "值"})
+    assert "名" in payload
+    assert canonical_call_key("t", {"名": "值"}).startswith("t:")
+
+
+def test_stable_call_id_fallback_deterministic() -> None:
+    first = stable_call_id(
+        "",
+        tool_name="echo",
+        iteration=2,
+        position=1,
+    )
+    second = stable_call_id(
+        None,
+        tool_name="echo",
+        iteration=2,
+        position=1,
+    )
+    assert first == second == "synth-echo-2-1"
+    assert (
+        stable_call_id(
+            "call_abc",
+            tool_name="echo",
+            iteration=2,
+            position=1,
+        )
+        == "call_abc"
+    )
+
+
+def test_diff_fields_reports_changed_key() -> None:
+    assert diff_canonical_fields({"a": 1, "b": 2}, {"a": 1, "b": 3}) == ("b",)

--- a/tests/test_reliability_ledger.py
+++ b/tests/test_reliability_ledger.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the append-only tool-call ledger.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agenticx.reliability.call_ledger import CallLedger, Verdict
+from agenticx.reliability.errors import LedgerCorruptError, ToolCallIdentityError
+
+
+def _ledger(tmp_path: Path, session_id: str = "sess-1", **kwargs) -> CallLedger:
+    return CallLedger(session_id, root=tmp_path, **kwargs)
+
+
+def test_fresh_when_unseen(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    result = ledger.reconcile("c1", "echo", {"text": "hi"})
+    assert result.verdict is Verdict.FRESH
+    assert result.record is None
+
+
+def test_replay_skip_returns_stored_result(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"text": "hi"})
+    ledger.record_result("c1", "OK")
+    result = ledger.reconcile("c1", "echo", {"text": "hi"})
+    assert result.verdict is Verdict.REPLAY_SKIP
+    assert result.replay_result == "OK"
+
+
+def test_ambiguous_when_dispatched_only(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"text": "hi"})
+    result = ledger.reconcile("c1", "echo", {"text": "hi"})
+    assert result.verdict is Verdict.AMBIGUOUS
+
+
+def test_failed_becomes_fresh(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"text": "hi"})
+    ledger.record_failure("c1", "boom")
+    result = ledger.reconcile("c1", "echo", {"text": "hi"})
+    assert result.verdict is Verdict.FRESH
+
+
+def test_identity_conflict_raises(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"a": 1, "b": 2})
+    with pytest.raises(ToolCallIdentityError) as excinfo:
+        ledger.reconcile("c1", "echo", {"a": 1, "b": 3})
+    message = str(excinfo.value)
+    assert "c1" in message
+    assert "b" in message
+
+
+def test_reconcile_safe_does_not_raise(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"a": 1, "b": 2})
+    result = ledger.reconcile_safe("c1", "echo", {"a": 1, "b": 3})
+    assert result.verdict is Verdict.IDENTITY_CONFLICT
+
+
+def test_large_result_not_inlined(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path, max_inline_result_bytes=8)
+    ledger.record_dispatch("c1", "echo", {"text": "hi"})
+    ledger.record_result("c1", "x" * 100)
+    result = ledger.reconcile("c1", "echo", {"text": "hi"})
+    assert result.verdict is Verdict.AMBIGUOUS
+    record = ledger.lookup("c1")
+    assert record is not None
+    assert record.result_digest
+    assert record.result_payload is None
+
+
+def test_survives_reload(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"n": 1})
+    ledger.record_result("c1", "one")
+    ledger.record_dispatch("c2", "echo", {"n": 2})
+    ledger.record_dispatch("c3", "echo", {"n": 3})
+    ledger.record_failure("c3", "nope")
+    ledger.close()
+
+    restored = CallLedger.load("sess-1", root=tmp_path)
+    assert restored.lookup("c1") is not None
+    assert restored.lookup("c2") is not None
+    assert restored.lookup("c3") is not None
+    assert restored.reconcile("c1", "echo", {"n": 1}).verdict is Verdict.REPLAY_SKIP
+    assert restored.reconcile("c2", "echo", {"n": 2}).verdict is Verdict.AMBIGUOUS
+    assert restored.reconcile("c3", "echo", {"n": 3}).verdict is Verdict.FRESH
+
+
+def test_pending_call_ids(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("a", "echo", {"n": 1})
+    ledger.record_dispatch("b", "echo", {"n": 2})
+    ledger.record_dispatch("c", "echo", {"n": 3})
+    ledger.record_result("c", "done")
+    assert set(ledger.pending_call_ids()) == {"a", "b"}
+
+
+def test_write_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ledger = _ledger(tmp_path)
+
+    def _boom(_fd: int) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("os.fsync", _boom)
+    with pytest.raises(OSError):
+        ledger.record_dispatch("c1", "echo", {"text": "hi"})
+
+
+def test_corrupt_file_raises(tmp_path: Path) -> None:
+    path = tmp_path / "sess-1"
+    path.mkdir()
+    (path / "call_ledger.jsonl").write_text("not json\n", encoding="utf-8")
+    with pytest.raises(LedgerCorruptError):
+        CallLedger.load("sess-1", root=tmp_path)
+
+
+def test_partial_corrupt_line_skipped(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"n": 1})
+    ledger.record_dispatch("c2", "echo", {"n": 2})
+    ledger.record_dispatch("c3", "echo", {"n": 3})
+    ledger.close()
+
+    file_path = tmp_path / "sess-1" / "call_ledger.jsonl"
+    lines = file_path.read_text(encoding="utf-8").splitlines()
+    lines[1] = "not-json-line"
+    file_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    restored = CallLedger.load("sess-1", root=tmp_path)
+    assert restored.lookup("c1") is not None
+    assert restored.lookup("c2") is None
+    assert restored.lookup("c3") is not None
+
+
+def test_unknown_schema_version_skipped(tmp_path: Path) -> None:
+    path = tmp_path / "sess-1"
+    path.mkdir()
+    (path / "call_ledger.jsonl").write_text(
+        '{"v": 99, "op": "dispatch", "call_id": "c99", "tool_name": "echo"}\n',
+        encoding="utf-8",
+    )
+    restored = CallLedger.load("sess-1", root=tmp_path)
+    assert restored.lookup("c99") is None
+
+
+def test_path_traversal_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        CallLedger("../evil", root=tmp_path)
+
+
+def test_jsonl_is_append_only(tmp_path: Path) -> None:
+    ledger = _ledger(tmp_path)
+    ledger.record_dispatch("c1", "echo", {"n": 1})
+    ledger.record_dispatch("c2", "echo", {"n": 2})
+    ledger.record_dispatch("c3", "echo", {"n": 3})
+    file_path = tmp_path / "sess-1" / "call_ledger.jsonl"
+    assert len(file_path.read_text(encoding="utf-8").splitlines()) == 3
+    ledger.record_result("c1", "ok")
+    assert len(file_path.read_text(encoding="utf-8").splitlines()) == 4

--- a/tests/test_reliability_posture.py
+++ b/tests/test_reliability_posture.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Tests for reliability.posture and fail-closed checkpoint visibility.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from agenticx.runtime.checkpoint import AgentCheckpoint, CheckpointStore
+from agenticx.runtime.harden_flags import (
+    cancelled_prefix_finalize_enabled,
+    fresh_round_loop_enabled,
+    interrupted_closers_enabled,
+    max_overflow_retries,
+    overflow_retry_enabled,
+    persist_fail_closed_enabled,
+    reliability_posture,
+)
+from agenticx.studio.storage.backend import SyncStorageFacade
+from agenticx.studio.storage.local_file import LocalFileBackend
+
+
+@pytest.fixture
+def isolated_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "AGX_RELIABILITY_POSTURE",
+        "AGX_PERSIST_FAIL_CLOSED",
+        "AGX_OVERFLOW_RETRY",
+        "AGX_MAX_OVERFLOW_RETRIES",
+        "AGX_INTERRUPTED_CLOSERS",
+        "AGX_CANCELLED_PREFIX_FINALIZE",
+        "AGX_FRESH_ROUND_LOOP",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr("agenticx.runtime.harden_flags._config_bool", lambda _key: None)
+    monkeypatch.setattr("agenticx.runtime.harden_flags._config_int", lambda _key: None)
+    monkeypatch.setattr("agenticx.runtime.harden_flags._config_str", lambda _key: None)
+
+
+def test_default_posture_is_strict(isolated_flags: None) -> None:
+    assert reliability_posture() == "strict"
+
+
+def test_env_selects_legacy(isolated_flags: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "legacy")
+    assert reliability_posture() == "legacy"
+
+
+def test_env_case_insensitive(isolated_flags: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "STRICT")
+    assert reliability_posture() == "strict"
+
+
+def test_typo_falls_back_to_strict(isolated_flags: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "struct")
+    assert reliability_posture() == "strict"
+
+
+def test_persist_default_follows_posture(
+    isolated_flags: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert persist_fail_closed_enabled() is True
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "legacy")
+    assert persist_fail_closed_enabled() is False
+
+
+def test_explicit_flag_overrides_posture(
+    isolated_flags: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "strict")
+    monkeypatch.setenv("AGX_PERSIST_FAIL_CLOSED", "0")
+    assert persist_fail_closed_enabled() is False
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "legacy")
+    monkeypatch.setenv("AGX_PERSIST_FAIL_CLOSED", "1")
+    assert persist_fail_closed_enabled() is True
+
+
+def test_other_flags_unchanged(isolated_flags: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "strict")
+    strict_vals = (
+        overflow_retry_enabled(),
+        interrupted_closers_enabled(),
+        cancelled_prefix_finalize_enabled(),
+        fresh_round_loop_enabled(),
+        max_overflow_retries(),
+    )
+    monkeypatch.setenv("AGX_RELIABILITY_POSTURE", "legacy")
+    legacy_vals = (
+        overflow_retry_enabled(),
+        interrupted_closers_enabled(),
+        cancelled_prefix_finalize_enabled(),
+        fresh_round_loop_enabled(),
+        max_overflow_retries(),
+    )
+    assert strict_vals == legacy_vals
+
+
+def test_checkpoint_save_returns_true_on_success(tmp_path: Path) -> None:
+    store = CheckpointStore(
+        SyncStorageFacade(
+            LocalFileBackend(
+                sessions_root=tmp_path / "sessions",
+                config_dir=tmp_path / "cfg",
+            )
+        )
+    )
+    ok = store.save(AgentCheckpoint(session_id="s1", turn_id="t1"))
+    assert ok is True
+    assert store.save_failures == 0
+
+
+def test_checkpoint_save_returns_false_on_failure() -> None:
+    class _Boom:
+        def save_agent_state(self, *_args, **_kwargs):
+            raise OSError("disk full")
+
+    store = CheckpointStore(storage=_Boom())  # type: ignore[arg-type]
+    ok = store.save(AgentCheckpoint(session_id="s-fail", turn_id="t1"))
+    assert ok is False
+    assert store.save_failures == 1
+
+
+def test_checkpoint_first_failure_logs_error(caplog: pytest.LogCaptureFixture) -> None:
+    class _Boom:
+        def save_agent_state(self, *_args, **_kwargs):
+            raise OSError("disk full")
+
+    store = CheckpointStore(storage=_Boom())  # type: ignore[arg-type]
+    caplog.set_level(logging.WARNING, logger="agenticx.runtime.checkpoint")
+    store.save(AgentCheckpoint(session_id="sess-log", turn_id="t1"))
+    store.save(AgentCheckpoint(session_id="sess-log", turn_id="t1"))
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warn_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert error_records
+    assert warn_records
+    assert "sess-log" in error_records[0].getMessage()
+    assert "sess-log" in warn_records[0].getMessage()
+
+
+def test_reliability_import_stays_clean() -> None:
+    for name in list(sys.modules):
+        if name.startswith("agenticx.studio"):
+            del sys.modules[name]
+    import importlib
+
+    import agenticx.reliability as reliability
+
+    importlib.reload(reliability)
+    bad = sorted(m for m in sys.modules if m.startswith("agenticx.studio"))
+    assert not bad

--- a/tests/test_reliability_replay_policy.py
+++ b/tests/test_reliability_replay_policy.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Tests for replay-safety policy and BaseTool.effect_class.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import pytest
+
+from agenticx.reliability.call_ledger import Verdict
+from agenticx.reliability.replay_policy import ReplayRequest, decide_replay
+from agenticx.tools.base import BaseTool
+
+
+def _req(**overrides: Any) -> ReplayRequest:
+    payload: Dict[str, Any] = {
+        "call_id": "c1",
+        "tool_name": "bump",
+        "arguments": {"key": "a"},
+        "ledger_verdict": Verdict.AMBIGUOUS,
+        "effect_class": "read",
+        "output_already_emitted": False,
+        "request_is_streaming": False,
+        "approve_unsafe_replay": False,
+    }
+    payload.update(overrides)
+    return ReplayRequest(**payload)
+
+
+def test_fresh_always_replays() -> None:
+    for effect in ("none", "read", "local_write", "external_write", "unknown"):
+        decision = decide_replay(_req(ledger_verdict=Verdict.FRESH, effect_class=effect))
+        assert decision.action == "replay"
+        assert decision.veto is None
+
+
+def test_replay_skip_uses_recorded() -> None:
+    decision = decide_replay(_req(ledger_verdict=Verdict.REPLAY_SKIP))
+    assert decision.action == "skip_use_recorded"
+
+
+def test_identity_conflict_aborts() -> None:
+    decision = decide_replay(_req(ledger_verdict=Verdict.IDENTITY_CONFLICT))
+    assert decision.action == "abort"
+    assert decision.veto == "identity_conflict"
+
+
+def test_identity_conflict_ignores_approval() -> None:
+    decision = decide_replay(
+        _req(ledger_verdict=Verdict.IDENTITY_CONFLICT, approve_unsafe_replay=True)
+    )
+    assert decision.action == "abort"
+    assert decision.veto == "identity_conflict"
+    assert "已忽略" in decision.reason
+
+
+def test_output_emitted_hard_veto() -> None:
+    decision = decide_replay(
+        _req(
+            ledger_verdict=Verdict.AMBIGUOUS,
+            effect_class="read",
+            output_already_emitted=True,
+            approve_unsafe_replay=True,
+        )
+    )
+    assert decision.action == "mark_unknown"
+    assert decision.veto == "output_already_emitted"
+    assert decision.approved_override is False
+
+
+def test_ambiguous_read_replays() -> None:
+    decision = decide_replay(_req(effect_class="read"))
+    assert decision.action == "replay"
+
+
+def test_ambiguous_none_replays() -> None:
+    decision = decide_replay(_req(effect_class="none"))
+    assert decision.action == "replay"
+
+
+def test_ambiguous_external_write_marks_unknown() -> None:
+    decision = decide_replay(_req(effect_class="external_write"))
+    assert decision.action == "mark_unknown"
+    assert decision.veto == "external_side_effect"
+
+
+def test_ambiguous_unknown_marks_unknown() -> None:
+    decision = decide_replay(_req(effect_class="unknown"))
+    assert decision.action == "mark_unknown"
+    assert decision.veto == "unknown_side_effect"
+
+
+def test_ambiguous_local_write_marks_unknown() -> None:
+    decision = decide_replay(_req(effect_class="local_write"))
+    assert decision.action == "mark_unknown"
+    assert decision.veto == "local_write_ambiguous"
+
+
+def test_approval_overrides_soft_veto() -> None:
+    decision = decide_replay(
+        _req(
+            effect_class="external_write",
+            approve_unsafe_replay=True,
+            output_already_emitted=False,
+            request_is_streaming=False,
+        )
+    )
+    assert decision.action == "replay"
+    assert decision.approved_override is True
+    assert decision.veto == "external_side_effect"
+
+
+def test_reason_contains_tool_name() -> None:
+    requests = [
+        _req(ledger_verdict=Verdict.FRESH, effect_class="external_write"),
+        _req(ledger_verdict=Verdict.REPLAY_SKIP),
+        _req(ledger_verdict=Verdict.IDENTITY_CONFLICT),
+        _req(ledger_verdict=Verdict.IDENTITY_CONFLICT, approve_unsafe_replay=True),
+        _req(output_already_emitted=True, approve_unsafe_replay=True),
+        _req(effect_class="read"),
+        _req(effect_class="none"),
+        _req(effect_class="external_write"),
+        _req(effect_class="unknown"),
+        _req(effect_class="local_write"),
+        _req(
+            effect_class="external_write",
+            approve_unsafe_replay=True,
+            request_is_streaming=False,
+        ),
+        _req(request_is_streaming=True),
+    ]
+    for req in requests:
+        decision = decide_replay(req)
+        assert req.tool_name in decision.reason, (req, decision)
+
+
+def test_veto_order_identity_before_output() -> None:
+    decision = decide_replay(
+        _req(
+            ledger_verdict=Verdict.IDENTITY_CONFLICT,
+            output_already_emitted=True,
+        )
+    )
+    assert decision.veto == "identity_conflict"
+
+
+class _NamedTool(BaseTool):
+    def _run(self, **kwargs: Any) -> str:
+        return "ok"
+
+
+class _ReadEmailTool(BaseTool):
+    effect_class = "read"
+
+    def _run(self, **kwargs: Any) -> str:
+        return "ok"
+
+
+class _BogusTool(BaseTool):
+    effect_class = "totally_bogus"
+
+    def _run(self, **kwargs: Any) -> str:
+        return "ok"
+
+
+def test_declared_effect_class_wins() -> None:
+    tool = _ReadEmailTool(name="send_email", description="declared read")
+    assert tool.resolve_effect_class({"to": "a@b.c"}) == "read"
+
+
+def test_falls_back_to_classifier() -> None:
+    reader = _NamedTool(name="file_read", description="read")
+    pusher = _NamedTool(name="git_push", description="push")
+    assert reader.resolve_effect_class() == "read"
+    assert pusher.resolve_effect_class() == "external_write"
+
+
+def test_bash_exec_uses_command() -> None:
+    tool = _NamedTool(name="bash_exec", description="shell")
+    assert (
+        tool.resolve_effect_class({"command": "git push origin main"})
+        == "external_write"
+    )
+    assert tool.resolve_effect_class({"command": "ls -la"}) == "read"
+
+
+def test_unknown_tool_is_unknown() -> None:
+    tool = _NamedTool(name="my_custom_thing", description="custom")
+    assert tool.resolve_effect_class() == "unknown"
+
+
+def test_invalid_declaration_raises() -> None:
+    tool = _BogusTool(name="weird", description="bad class")
+    with pytest.raises(ValueError):
+        tool.resolve_effect_class()

--- a/tests/test_reliability_run_state.py
+++ b/tests/test_reliability_run_state.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for SDK RunState persistence.
+
+Author: Damon Li
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agenticx.reliability import run_state as run_state_mod
+from agenticx.reliability.run_state import (
+    PendingCall,
+    RunState,
+    RunStateStore,
+)
+
+
+def test_roundtrip() -> None:
+    state = RunState(
+        run_id="r1",
+        session_id="s1",
+        query="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        iteration=2,
+        phase="tools_dispatched",
+        pending_calls=[
+            PendingCall(
+                call_id="c1",
+                tool_name="echo",
+                arguments={"text": "hi"},
+                canonical_key="echo:abc",
+            )
+        ],
+        created_at=1.0,
+        updated_at=2.0,
+    )
+    restored = RunState.from_dict(state.to_dict())
+    assert restored == state
+
+
+def test_save_load_clear(tmp_path: Path) -> None:
+    store = RunStateStore("sess-1", root=tmp_path)
+    state = RunState(run_id="r1", session_id="sess-1", query="q")
+    store.save(state)
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.run_id == "r1"
+    assert loaded.query == "q"
+    store.clear()
+    assert store.load() is None
+
+
+def test_load_missing_returns_none(tmp_path: Path) -> None:
+    assert RunStateStore("sess-1", root=tmp_path).load() is None
+
+
+def test_future_schema_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "sess-1"
+    path.mkdir()
+    (path / "run_state.json").write_text(
+        json.dumps({"schema_version": 999, "run_id": "r", "session_id": "sess-1"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        RunStateStore("sess-1", root=tmp_path).load()
+
+
+def test_save_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_args, **_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(run_state_mod, "atomic_write_json", _boom)
+    store = RunStateStore("sess-1", root=tmp_path)
+    with pytest.raises(OSError):
+        store.save(RunState(run_id="r1", session_id="sess-1"))
+
+
+def test_atomic_no_partial_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = RunStateStore("sess-1", root=tmp_path)
+    original = RunState(run_id="keep-me", session_id="sess-1", query="ok")
+    store.save(original)
+
+    def _boom(*_args, **_kwargs) -> None:
+        raise OSError("mid-write")
+
+    monkeypatch.setattr(run_state_mod, "atomic_write_json", _boom)
+    with pytest.raises(OSError):
+        store.save(RunState(run_id="new", session_id="sess-1", query="nope"))
+    loaded = store.load()
+    assert loaded is not None
+    assert loaded.run_id == "keep-me"
+    assert loaded.query == "ok"
+
+
+def test_path_traversal_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        RunStateStore("../evil", root=tmp_path)


### PR DESCRIPTION
## Summary
- Add an SDK reliability kernel: canonical tool-call identity, a JSONL call ledger, persisted run state, `ReActAgent.aresume()`, and layered replay vetoes so a crashed write is not blindly re-executed.
- Add an in-process fault-injection bench (`agenticx-reliability-v1`) that reports duplicate side-effect rate, crash-recovery success, history consistency, and error diagnosability.
- Default `reliability.posture` to fail-closed (`strict`), document the bench numbers, and leave Desktop GUI wiring as a pending follow-up. Studio `/api/chat` and `AgentRuntime` are intentionally not connected in this phase.

## Test plan
- [ ] `pytest tests/test_reliability_call_identity.py tests/test_reliability_ledger.py tests/test_reliability_run_state.py tests/test_react_agent_resume.py tests/test_reliability_replay_policy.py --noconftest --override-ini="addopts="`
- [ ] `pytest tests/test_reliability_bench.py tests/test_reliability_posture.py tests/test_smoke_persist_fail_closed.py --noconftest --override-ini="addopts="`
- [ ] Run the built-in bench and confirm `duplicate_side_effect_rate == 0.0` and the other three rates are `1.0`:
  ```bash
  python -c "
  from pathlib import Path
  from agenticx.evaluation import EvalSet, ReliabilityRunner
  import tempfile
  es = EvalSet.from_file('agenticx/evaluation/benchmarks/reliability_v1.json')
  with tempfile.TemporaryDirectory() as d:
      print(ReliabilityRunner(root=Path(d)).run(es).to_report())
  "
  ```
- [ ] Confirm Near chat / `/api/chat` is unchanged: this PR does not resume desktop conversations after a crash.